### PR TITLE
feat: add Claude Code review workflow template

### DIFF
--- a/bin/ai-guardrails-init
+++ b/bin/ai-guardrails-init
@@ -56,6 +56,8 @@ Options:
   --no-pip-audit     Disable pip-audit hook
   --ci               Install CI workflow (.github/workflows/check.yml)
   --no-ci            Skip CI workflow installation
+  --claude-review    Install Claude Code review workflow
+  --no-claude-review Skip Claude Code review workflow
   --coderabbit       Install CodeRabbit config (.coderabbit.yaml)
   --no-coderabbit    Skip CodeRabbit config installation
   -h, --help         Show this help
@@ -73,6 +75,7 @@ Languages supported (auto-detected or via --type):
 Also installs (for GitHub projects):
   .coderabbit.yaml    CodeRabbit AI reviewer config (assertive + approval workflow)
   check.yml           CI workflow for pre-commit checks
+  claude-review.yml   Claude Code review workflow (AI-powered PR review)
 
 Examples:
   ai-guardrails-init                   # Auto-detect project type
@@ -88,6 +91,7 @@ SKIP_PRECOMMIT=false
 COPY_ALL=false
 PIP_AUDIT_MODE="auto"
 INSTALL_CI="auto"
+INSTALL_CLAUDE_REVIEW="auto"
 INSTALL_CODERABBIT="auto"
 detected=""
 
@@ -127,6 +131,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-ci)
       INSTALL_CI="no"
+      shift
+      ;;
+    --claude-review)
+      INSTALL_CLAUDE_REVIEW="yes"
+      shift
+      ;;
+    --no-claude-review)
+      INSTALL_CLAUDE_REVIEW="no"
       shift
       ;;
     --coderabbit)
@@ -433,6 +445,27 @@ if [[ "$INSTALL_CI" == "yes" ]]; then
     copy_config "$TEMPLATES_DIR/workflows/check.yml" ".github/workflows/check.yml"
   else
     echo -e "  ${YELLOW}⚠ CI workflow template not found${NC}"
+  fi
+fi
+
+# Install Claude Code review workflow
+if [[ "$INSTALL_CLAUDE_REVIEW" == "auto" && -d ".git" ]]; then
+  # Auto: install if .github directory exists or this looks like a GitHub project
+  if [[ -d ".github" ]] || git remote -v 2>/dev/null | grep -q "github.com"; then
+    INSTALL_CLAUDE_REVIEW="yes"
+  fi
+fi
+
+if [[ "$INSTALL_CLAUDE_REVIEW" == "yes" ]]; then
+  echo
+  echo -e "${GREEN}Setting up Claude Code review...${NC}"
+  mkdir -p .github/workflows
+  if [[ -f "$TEMPLATES_DIR/workflows/claude-review.yml" ]]; then
+    copy_config "$TEMPLATES_DIR/workflows/claude-review.yml" ".github/workflows/claude-review.yml"
+    echo -e "  ${BLUE}→ Note: This workflow requires OIDC auth (must be on default branch first)${NC}"
+    echo -e "  ${BLUE}→ Or provide anthropic_api_key in workflow secrets${NC}"
+  else
+    echo -e "  ${YELLOW}⚠ Claude review workflow template not found${NC}"
   fi
 fi
 

--- a/templates/workflows/claude-review.yml
+++ b/templates/workflows/claude-review.yml
@@ -1,0 +1,53 @@
+# AI Guardrails - Claude Code Review Workflow
+# Automated code review using Claude Code Action
+# Note: This workflow must exist on the default branch (main) for OIDC auth to work
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    name: Claude Code Review
+    # Run on PR events, or on issue comments that mention @claude
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@beta
+        with:
+          # Use OIDC authentication (requires workflow on default branch)
+          # Alternatively, provide anthropic_api_key for direct API access
+          use_oauth: true
+
+          # Review configuration
+          model: claude-sonnet-4-20250514
+          timeout_minutes: 10
+
+          # Custom prompt for code review focus
+          custom_instructions: |
+            Focus on:
+            - Security vulnerabilities (OWASP top 10)
+            - Code correctness and edge cases
+            - Performance issues
+            - Adherence to project conventions in CLAUDE.md
+            - Test coverage gaps
+
+            Be concise. Prioritize actionable feedback.
+            Use severity levels: critical, major, minor, suggestion.


### PR DESCRIPTION
## Summary

- Add `templates/workflows/claude-review.yml` for AI-powered PR reviews using Claude Code Action
- Add `--claude-review` / `--no-claude-review` flags to `ai-guardrails-init`
- Auto-installs for GitHub projects (same behavior as check.yml and coderabbit)

## Why a separate PR?

The Claude Code Action requires the workflow file to exist on the repository's **default branch** (main) before OIDC authentication works. This PR adds it to main so other branches/PRs can use it.

## Usage

After merging, new projects using `ai-guardrails-init` will get the workflow automatically.

For existing projects:
```bash
ai-guardrails-init --claude-review --force
```

## Authentication Options

1. **OIDC (default)** - No secrets needed, but workflow must be on default branch first
2. **API Key** - Add `ANTHROPIC_API_KEY` to repository secrets and modify workflow

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)