### PR TITLE
fix: add allowed_tools for Claude Code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,8 +34,16 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          additional_permissions: |
-            actions: read
+          allowed_tools: |
+            Bash(gh pr *)
+            Bash(gh api *)
+            Bash(git diff *)
+            Bash(git log *)
+            Bash(git show *)
+            Read
+            Glob
+            Grep
+            mcp__github__*
           prompt: |
             Review PR ${{ github.repository }}/pull/${{ github.event.pull_request.number }} with comprehensive analysis:
 


### PR DESCRIPTION
## Summary

Claude Code review was getting permission denials when trying to fetch PR data:
```
"permission_denials": [
  {"tool_name": "Bash", "command": "gh pr view 4 ..."},
  {"tool_name": "Bash", "command": "gh pr diff 4"}
]
```

Added `allowed_tools` to permit:
- `gh pr/api` commands for PR metadata
- `git diff/log/show` for code changes  
- `Read/Glob/Grep` for file access
- `mcp__github__*` for GitHub API

## Test plan

- [ ] Merge this PR
- [ ] PR #4 will trigger claude-review again
- [ ] Claude should now be able to fetch PR data and post actual reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review workflow configuration to enhance available capabilities and permissions for the code review process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->