### PR TITLE
feat: Claude spec-focused PR review workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Intent
+
+<!-- Why is this change needed? What problem does it solve? -->
+
+## Scope
+
+<!-- What components/files are affected? What is NOT changing? -->
+
+**Affected areas:**
+-
+
+**Out of scope:**
+-
+
+## Acceptance Criteria
+
+<!-- How do we know this is done? List testable conditions -->
+
+- [ ]
+- [ ]
+
+## Test Plan
+
+<!-- How to verify this works? Manual steps? Automated tests? -->
+
+## Breaking Changes
+
+<!-- Any breaking changes? If yes, describe migration path -->
+
+- [ ] No breaking changes
+- [ ] Breaking changes (describe below)
+
+---
+
+<!--
+Review checklist (for reviewers):
+- [ ] PR structure complete (intent, scope, criteria, test plan)
+- [ ] Architecture compliance (correct layering, no circular deps)
+- [ ] Spec alignment (matches .claude/specs/ if applicable)
+- [ ] Documentation updated (README, API docs if needed)
+-->

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,9 +1,8 @@
-name: Claude Code Review
+name: Claude Architecture & Spec Review
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-  # Also trigger on review requests
   pull_request_target:
     types: [review_requested]
 
@@ -14,11 +13,15 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # Push fixes/suggestions
-      pull-requests: write  # Post reviews, approve, request changes
-      issues: write         # Create/comment on issues
-      id-token: write       # OIDC authentication
-      actions: read         # Read CI results
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    # Prevent parallel runs on same PR
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository
@@ -27,31 +30,122 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Run Claude Code Review
-        id: claude-review
+      - name: Claude Architecture & Spec Review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          additional_permissions: |
-            actions: read
+          track_progress: true
+
           prompt: |
-            Review PR ${{ github.repository }}/pull/${{ github.event.pull_request.number }} with comprehensive analysis:
+            # ARCHITECTURE & SPEC REVIEW
 
-            1. **Code Quality**: Check for code smells, complexity, maintainability, DRY violations, proper naming
-            2. **Bugs & Logic Errors**: Identify potential runtime errors, edge cases, null/undefined handling
-            3. **CLAUDE.md Adherence**: Verify all project-specific guidelines from CLAUDE.md are followed
-            4. **Best Practices**: Language-specific idioms, design patterns, error handling
-            5. **Performance**: Inefficient algorithms, unnecessary computations, memory leaks
-            6. **Security**: Injection vulnerabilities, authentication/authorization issues, data validation
-            7. **Testing**: Test coverage for new code, edge case coverage, test quality
-            8. **Documentation**: Code comments where needed, function/class documentation
+            Repository: ${{ github.repository }}
+            PR: #${{ github.event.pull_request.number }}
+            Title: ${{ github.event.pull_request.title }}
+            Author: ${{ github.event.pull_request.user.login }}
 
-            After review:
-            - Post inline comments on specific lines with issues
-            - Provide an overall summary as a PR review
-            - If no critical/major issues: APPROVE the PR
-            - If critical/major issues found: REQUEST_CHANGES with clear explanation
+            ## YOUR ROLE
 
-            Focus on: actionable feedback with specific line references, severity (critical/major/minor), and suggested fixes.
+            You are the ARCHITECTURE & SPEC reviewer. CodeRabbit handles code quality.
+
+            Your focus:
+            - Business requirements & intent
+            - Architectural decisions & patterns
+            - Spec compliance & documentation
+            - High-level PR overview
+
+            NOT your focus (CodeRabbit handles):
+            - Code style, formatting
+            - Small bugs, edge cases
+            - Performance micro-optimizations
+            - Language-specific idioms
+
+            ## REVIEW PROCESS
+
+            1. First, read `docs/specs/review-checklist.md` for requirements
+            2. Fetch the PR details with `gh pr view ${{ github.event.pull_request.number }}`
+            3. Get the diff with `gh pr diff ${{ github.event.pull_request.number }}`
+            4. Review against the checklist
+            5. Post your review as a PR comment
+
+            ## REVIEW CHECKLIST
+
+            ### 1. PR Structure (REQUIRED)
+
+            Check the PR body for:
+            - **Intent**: Why is this change needed?
+            - **Scope**: What components are affected?
+            - **Acceptance Criteria**: How do we know it's done?
+            - **Test Plan**: How to verify it works?
+
+            If ANY are missing -> REQUEST CHANGES with template.
+
+            ### 2. Architecture Compliance
+
+            - Correct layering (API -> Service -> Repo)
+            - No circular dependencies
+            - Proper separation of concerns
+            - Interface boundaries respected
+
+            ### 3. Spec Alignment
+
+            - Changes match documented specs in `docs/specs/`
+            - If behavior changes, spec is updated
+            - No undocumented breaking changes
+
+            ### 4. Documentation
+
+            - README updated for new features
+            - API docs reflect changes
+            - Migration guide for breaking changes
+
+            ## OUTPUT FORMAT
+
+            Post a PR comment using `gh pr comment` with this format:
+
+            ```
+            ## Architecture & Spec Review
+
+            ### Overview
+            [2-3 sentence summary of what this PR does at a high level]
+
+            ### Checklist Results
+
+            | Category | Status | Notes |
+            |----------|--------|-------|
+            | PR Structure | [status] | ... |
+            | Architecture | [status] | ... |
+            | Spec Compliance | [status] | ... |
+            | Documentation | [status] | ... |
+
+            ### Issues Found
+            [List specific issues if any]
+
+            ### Recommendation
+            [APPROVE / APPROVE with suggestions / REQUEST CHANGES]
+            ```
+
+            ## ENFORCEMENT
+
+            If PR body is missing required sections, include this template in your comment:
+
+            ---
+            **Please update your PR description with:**
+
+            ### Intent
+            [Why is this change needed? What problem does it solve?]
+
+            ### Scope
+            [What components/files are affected? What's NOT changing?]
+
+            ### Acceptance Criteria
+            - [ ] Criterion 1
+            - [ ] Criterion 2
+
+            ### Test Plan
+            [How to verify this works?]
+            ---
+
+          claude_args: |
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep"
+            --max-turns 10

--- a/docs/specs/review-checklist.md
+++ b/docs/specs/review-checklist.md
@@ -1,0 +1,90 @@
+# PR Review Checklist - Architecture & Specs
+
+Claude Code reviews against this checklist. CodeRabbit handles code quality.
+
+## Required PR Structure
+
+Every PR MUST have:
+
+### 1. Intent Section
+- [ ] Clear problem statement or feature description
+- [ ] Link to issue/spec if applicable
+- [ ] Why this change is needed (business justification)
+
+### 2. Scope Section
+- [ ] List of affected components/files
+- [ ] What is NOT changing (boundaries)
+- [ ] Breaking changes clearly marked
+
+### 3. Acceptance Criteria
+- [ ] Testable success conditions
+- [ ] Edge cases considered
+- [ ] Rollback plan for risky changes
+
+### 4. Test Plan
+- [ ] How to verify the change works
+- [ ] Manual testing steps if applicable
+- [ ] Automated test coverage
+
+## Architecture Rules
+
+### Layering (MANDATORY)
+```
+API Controllers → Services → Repositories → Database
+       ↓              ↓            ↓
+   Validation    Business     Data Access
+                  Logic
+```
+
+- Controllers: HTTP handling, input validation, response formatting
+- Services: Business logic, orchestration, no direct DB access
+- Repositories: Data access only, no business logic
+
+### Dependency Direction
+- Dependencies flow inward (outer layers depend on inner)
+- Core business logic has NO external dependencies
+- Use interfaces/abstractions at boundaries
+
+### File Organization
+```
+src/
+├── api/          # HTTP layer
+├── services/     # Business logic
+├── repos/        # Data access
+├── models/       # Domain models
+├── utils/        # Shared utilities
+└── types/        # Type definitions
+```
+
+## Security Checklist
+
+- [ ] No hardcoded secrets (use env vars)
+- [ ] Input validation at all entry points
+- [ ] AuthZ checks on every mutation
+- [ ] Parameterized queries (no string concat SQL)
+- [ ] No eval(), exec(), or dynamic code execution
+- [ ] Sensitive data not logged
+
+## Documentation Requirements
+
+### When to Update Docs
+- New feature → Update README
+- API change → Update API docs
+- Config change → Update setup guide
+- Breaking change → Migration guide required
+
+### Spec Updates
+If changing behavior documented in `.claude/specs/`:
+- [ ] Spec updated BEFORE code change
+- [ ] Spec change reviewed separately or clearly marked
+
+## Fail Conditions
+
+Claude MUST REQUEST CHANGES if:
+
+1. **No acceptance criteria** in PR body
+2. **Spec mismatch** - code doesn't match documented behavior
+3. **Architecture violation** - wrong layer dependencies
+4. **Missing docs** - new feature without documentation
+5. **Security gap** - fails security checklist
+6. **Scope creep** - changes beyond stated intent


### PR DESCRIPTION
## Intent

Setup Claude Code for **architecture & spec reviews** while CodeRabbit handles code quality. This creates a clear division of responsibility:

| Reviewer | Focus |
|----------|-------|
| **CodeRabbit** | Code quality, bugs, style, performance, language idioms |
| **Claude** | Architecture, specs, business requirements, documentation |

## Scope

**New files:**
- `docs/specs/review-checklist.md` - Review requirements Claude enforces
- `.github/PULL_REQUEST_TEMPLATE.md` - Enforced PR structure

**Modified:**
- `.github/workflows/claude-code-review.yml` - Spec-focused review workflow

**Out of scope:**
- CodeRabbit configuration (unchanged)
- CI/CD workflows (unchanged)

## Acceptance Criteria

- [ ] Claude workflow uses v1.0 syntax (`claude_args` with `--allowedTools`)
- [ ] Claude posts structured review comments
- [ ] PR template enforces required sections
- [ ] Specs in `docs/specs/` (not `.claude/`)

## Test Plan

1. Merge this PR
2. Create a test PR without proper structure
3. Claude should REQUEST CHANGES with template
4. Update PR with proper structure
5. Claude should post structured review

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking changes: Claude workflow now focused on specs, not code quality

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)