### PR TITLE
fix: remove labeled trigger from claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,13 +1,14 @@
 name: Claude Architecture & Spec Review
 
 on:
-  # Trigger via /claude-review comment
+  # Trigger via /claude-review comment (primary manual trigger)
   issue_comment:
     types: [created]
 
-  # Trigger when PR has claude-review label
+  # Trigger on PR events when label is present
+  # Note: "labeled" action incompatible with track_progress, use /claude-review comment
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened, labeled]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Intent

Fix claude-review workflow failure when triggered by adding a label.

## Problem

The `labeled` action is incompatible with `track_progress: true`:
```
track_progress for pull_request events is only supported for actions: 
opened, synchronize, ready_for_review, reopened. Current action: labeled
```

## Solution

Remove `labeled` from pull_request triggers. Use `/claude-review` comment as manual trigger instead.

## How to trigger claude-review now

1. **Automatic**: Push to PR with `claude-review` label (synchronize event)
2. **Manual**: Comment `/claude-review` on any PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation trigger conditions. The workflow now responds to pull request state changes and can be explicitly triggered via a comment command or label on non-draft pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->