### PR TITLE
fix: correct headRepository field in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,9 +42,9 @@ jobs:
         if: github.event_name == 'issue_comment'
         id: pr-info
         run: |
-          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid,headRepository,number,title,author)
+          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid,headRepository,headRepositoryOwner,number,title,author)
           echo "head_sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> $GITHUB_OUTPUT
-          echo "head_repo=$(echo "$PR_DATA" | jq -r '.headRepository.owner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
+          echo "head_repo=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
           echo "number=$(echo "$PR_DATA" | jq -r '.number')" >> $GITHUB_OUTPUT
           echo "title=$(echo "$PR_DATA" | jq -r '.title')" >> $GITHUB_OUTPUT
           echo "author=$(echo "$PR_DATA" | jq -r '.author.login')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes the `claude-code-review.yml` workflow failing with "Invalid repository '/ai-guardrails'" error when triggered via `/claude-review` comment.

**Root cause:** `gh pr view` returns `headRepositoryOwner.login` not `headRepository.owner.login`.

## Changes

- Added `headRepositoryOwner` to JSON fields requested
- Use `.headRepositoryOwner.login` instead of `.headRepository.owner.login`

## Test Plan

- [ ] Merge this PR
- [ ] Trigger `/claude-review` on PR #14
- [ ] Verify checkout succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)