### PR TITLE
feat: add --no-verify warning to dangerous command check

### DIFF
--- a/lib/hooks/dangerous-command-check.sh
+++ b/lib/hooks/dangerous-command-check.sh
@@ -38,6 +38,14 @@ case "$COMMAND" in
     ;;
 esac
 
+# Patterns requiring explicit approval (allow but warn strongly)
+case "$COMMAND" in
+  *'--no-verify'*)
+    echo -e "${YELLOW}⚠ REQUIRES APPROVAL:${NC} --no-verify bypasses all pre-commit hooks."
+    echo -e "  This defeats the purpose of guardrails. Only proceed if user explicitly approves."
+    ;;
+esac
+
 # Warning patterns (allow but warn)
 case "$COMMAND" in
   *'rm -rf'*)


### PR DESCRIPTION
## Summary

- Adds explicit approval warning when `--no-verify` flag is detected in bash commands
- Warning informs the user that bypassing pre-commit hooks defeats the purpose of guardrails
- Allows command to proceed but requires explicit user approval

## Motivation

When using Claude Code with ai-guardrails, using `--no-verify` to bypass pre-commit hooks undermines the entire guardrail system. This warning ensures the user is aware and explicitly approves before proceeding.

## Test plan

- [ ] Run `dangerous-command-check.sh "git commit --no-verify -m test"` and verify warning is shown
- [ ] Run `dangerous-command-check.sh "git commit -m test"` and verify no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a safety warning when using the `--no-verify` option to inform developers that pre-commit hooks are bypassed and explicit approval is required to proceed with the action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->