### PR TITLE
fix: dangerous-command-check reads stdin JSON and blocks unsafe flags

### DIFF
--- a/lib/python/guardrails/hooks/dangerous_cmd.py
+++ b/lib/python/guardrails/hooks/dangerous_cmd.py
@@ -78,11 +78,17 @@ def _check_warned(command: str) -> list[str]:
 
 
 def _read_command_from_stdin() -> str:
-    """Read command from Claude Code PreToolUse JSON on stdin."""
+    """Read command from Claude Code PreToolUse JSON on stdin.
+
+    Returns empty string when stdin is a TTY (interactive session) or on
+    any I/O or parse error.
+    """
+    if sys.stdin.isatty():
+        return ""
     try:
         data = json.load(sys.stdin)
         return str(data.get("tool_input", {}).get("command", ""))
-    except (json.JSONDecodeError, AttributeError):
+    except (json.JSONDecodeError, AttributeError, OSError):
         return ""
 
 


### PR DESCRIPTION
## Summary

- **Fix stdin JSON protocol**: Claude Code PreToolUse hooks receive JSON on stdin, not via env vars. The hook was silently passing through ALL commands because argv was always empty.
- **Output to stderr**: Block/warn messages now go to stderr (required for Claude Code to feed messages back to the agent on exit 2).
- **Block gh admin flag**: Adds a regex-based check for the admin bypass flag on gh CLI which bypasses branch protection rules. Uses regex instead of substring match to avoid false positives in commit message text.
- **42 tests**: Added tests for stdin JSON parsing, admin flag blocking, stderr output, and false positive prevention.

## Test plan

- [x] 422 pytest tests pass (42 in dangerous_cmd alone)
- [x] ruff lint clean
- [x] ruff format clean
- [x] pyright clean (0 errors)
- [ ] Verify /review-all triggers all three review bots on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detection of dangerous commands attempting to bypass branch protection controls.

* **Bug Fixes**
  * Fixed output redirection for block and warning messages to stderr for proper error handling.

* **Tests**
  * Expanded test coverage for dangerous command detection and command input handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->