### PR TITLE
docs: strengthen AI agent push discipline rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,8 @@ and create noise. Only push when you are confident the code is complete.
 3. **Batch into minimal commits** — Group related changes into logical
    commits. Push them all at once
 4. **Address ALL review feedback before pushing again** — When bots request
-   changes, fix every comment locally, then push once
+   changes, fix every comment locally, then push once. Do not push after
+   each individual fix
 5. **Wait for all bots** — After pushing, wait for all reviews to complete
    (~5 min) before acting on feedback
 

--- a/templates/CLAUDE.md.guardrails
+++ b/templates/CLAUDE.md.guardrails
@@ -71,11 +71,17 @@ All bots auto-review every push. No manual triggers needed.
 Every push triggers all 4 review bots. Unnecessary pushes waste review cycles
 and create noise. Only push when you are confident the code is complete.
 
-1. **Complete all changes before pushing** — Finish the entire task locally (all files, all fixes, all tests passing). Do not push work-in-progress
-2. **Never auto-push** — Always ask the human before running `git push`. Explain what changed and confirm they want a review
-3. **Batch into minimal commits** — Group related changes into logical commits. Push them all at once
-4. **Address ALL review feedback before pushing again** — When bots request changes, fix every comment locally, then push once. Do not push after each individual fix
-5. **Wait for all bots** — After pushing, wait for all reviews to complete (~5 min) before acting on feedback
+1. **Complete all changes before pushing** — Finish the entire task locally
+   (all files, all fixes, all tests passing). Do not push work-in-progress
+2. **Never auto-push** — Always ask the human before running `git push`.
+   Explain what changed and confirm they want a review
+3. **Batch into minimal commits** — Group related changes into logical
+   commits. Push them all at once
+4. **Address ALL review feedback before pushing again** — When bots request
+   changes, fix every comment locally, then push once. Do not push after
+   each individual fix
+5. **Wait for all bots** — After pushing, wait for all reviews to complete
+   (~5 min) before acting on feedback
 
 ### When Pre-commit Fails
 


### PR DESCRIPTION
## Intent

Every push triggers 4 review bots (CodeRabbit, Claude, Gemini, DeepSource).
The existing 3 agent rules were too vague — agents still pushed
work-in-progress, triggering unnecessary review cycles.

## Scope

### Affected areas

- `CLAUDE.md` — expanded agent rules section
- `templates/CLAUDE.md.guardrails` — same changes for consumer projects

### Out of scope

- Workflow files, bot configs, review checklist

## Acceptance Criteria

- [ ] Agent rules expanded from 3 to 5 with explicit push discipline
- [ ] Rules explain WHY (every push = 4 bot reviews)
- [ ] Both CLAUDE.md and template are consistent

## Test Plan

- Read both files, verify rules are identical
- Verify markdownlint passes

## Breaking Changes

- [ ] No breaking changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised AI agent workflow with a new, expanded five-point ruleset and an introductory note about pushes triggering all review bots.
  * Clarified push and review procedures: complete changes locally, require human confirmation (no auto-push), batch minimal commits, and wait for all bot reviews.
  * Expanded guidance for handling pre-commit failures with concrete remediation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->