### PR TITLE
ci: add id-token: write to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,6 +21,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     concurrency:
       group: claude-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Claude Code Review workflow was failing on every PR with `Could not fetch an OIDC token`
- Root cause: missing `id-token: write` permission (the template already had it, deployed copy didn't)

## Test plan
- [ ] Merge this, then check that Claude Code Review runs successfully on PR #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-visible changes. Internal infrastructure updates were made to GitHub Actions workflow configuration to support enhanced CI/CD capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->