### PR TITLE
feat: disable CodeRabbit auto-review, manual trigger only

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,11 +17,17 @@ reviews:
   review_status: true
   collapse_walkthrough: false
 
-  # Auto-review on push — CodeRabbit reviews every push automatically.
-  # Subsequent pushes get incremental reviews (only changed code).
-  # To force a full re-review, comment "@coderabbitai full review".
+  # Manual review only — do NOT auto-review every push.
+  # Free tier allows only 3 reviews/hour. Auto-reviewing wastes them on
+  # WIP pushes that aren't ready for review.
+  #
+  # Workflow:
+  #   1. Push changes, let CI + Claude + DeepSource + Gemini run
+  #   2. Resolve ALL their comments first
+  #   3. Only then trigger: @coderabbitai review
+  #   4. For a full re-review: @coderabbitai full review
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     auto_incremental_review: true
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,19 +113,28 @@ uv run pytest tests/ --cov=lib/python/guardrails --cov-report=term-missing
 
 ## Review Bots
 
-All bots auto-review every push. No manual triggers needed.
-
 | Bot | Focus | Trigger |
 |-----|-------|---------|
-| CodeRabbit | Static analysis, security, language conventions | Auto on push |
-| Claude | Code duplication, clean code, modern patterns, architecture | Auto on PR |
+| CodeRabbit | Static analysis, security, language conventions | **Manual only** (`@coderabbitai review`) |
+| Claude | Code duplication, clean code, modern patterns, architecture | Auto on push |
 | Gemini | Bugs, logic errors, security, performance | Auto on push |
 | DeepSource | Anti-patterns, OWASP, code metrics | Auto on push |
 
+### CodeRabbit Review Workflow
+
+CodeRabbit is rate-limited (3 reviews/hour on free tier). Auto-review is
+disabled to avoid wasting reviews on WIP pushes.
+
+1. Push changes — CI, Claude, Gemini, and DeepSource run automatically
+2. Resolve ALL their comments first
+3. Only then trigger CodeRabbit: comment `@coderabbitai review` on the PR
+4. For a full re-review: `@coderabbitai full review`
+
 ### Rules for AI Agents
 
-Every push triggers all 4 review bots. Unnecessary pushes waste review cycles
-and create noise. Only push when you are confident the code is complete.
+Every push triggers 3 auto-review bots (Claude, Gemini, DeepSource).
+CodeRabbit must be triggered manually. Unnecessary pushes waste review
+cycles and create noise.
 
 1. **Complete all changes before pushing** — Finish the entire task locally
    (all files, all fixes, all tests passing). Do not push work-in-progress
@@ -136,8 +145,11 @@ and create noise. Only push when you are confident the code is complete.
 4. **Address ALL review feedback before pushing again** — When bots request
    changes, fix every comment locally, then push once. Do not push after
    each individual fix
-5. **Wait for all bots** — After pushing, wait for all reviews to complete
-   (~5 min) before acting on feedback
+5. **Wait for auto-review bots** — After pushing, wait for Claude, Gemini,
+   and DeepSource reviews to complete (~5 min) before acting on feedback
+6. **Trigger CodeRabbit last** — Only after all other bot comments are
+   resolved, trigger `@coderabbitai review`. This is the final gate before
+   merge
 
 ## Key Constraints
 

--- a/templates/.coderabbit.yaml
+++ b/templates/.coderabbit.yaml
@@ -31,11 +31,17 @@ reviews:
   # ============================================
   # Auto Review
   # ============================================
-  # Auto-review on push — CodeRabbit reviews every push automatically.
-  # Subsequent pushes get incremental reviews (only changed code).
-  # To force a full re-review, comment "@coderabbitai full review".
+  # Manual review only — do NOT auto-review every push.
+  # Free/OSS tier allows only 3 reviews/hour. Auto-reviewing wastes them
+  # on WIP pushes that aren't ready for review.
+  #
+  # Workflow:
+  #   1. Push changes, let CI and other review bots run
+  #   2. Resolve ALL their comments first
+  #   3. Only then trigger: @coderabbitai review
+  #   4. For a full re-review: @coderabbitai full review
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     auto_incremental_review: true
     # Ignore PRs from these users (e.g., bots)


### PR DESCRIPTION
## Summary

- Disable CodeRabbit auto-review on push (free tier: 3 reviews/hour)
- New workflow: resolve all other bot comments first, then trigger `@coderabbitai review` as final gate
- Updated both repo config and template for consumer projects
- Updated CLAUDE.md with new review bot workflow for AI agents

## Workflow (before → after)

**Before:** Every push triggers CodeRabbit → wastes 3-4 reviews on WIP pushes, hits rate limit, blocks merge

**After:**
1. Push → CI + Claude + Gemini + DeepSource run automatically
2. Resolve all their comments
3. `@coderabbitai review` → one intentional review when ready
4. Merge

## Test plan

- [ ] Verify CodeRabbit does NOT auto-review on push
- [ ] Verify `@coderabbitai review` still triggers a review
- [ ] Verify template matches repo config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeRabbit review configuration to require manual triggering instead of automatic reviews on push.

* **Documentation**
  * Updated review workflow documentation to clarify the new manual review process for CodeRabbit while maintaining automatic reviews for other analysis tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->