### PR TITLE
chore(ci): add guardrails-review workflow

### DIFF
--- a/.github/workflows/guardrails-review.yml
+++ b/.github/workflows/guardrails-review.yml
@@ -1,0 +1,29 @@
+name: Guardrails Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/guardrails-review'))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - uses: Questi0nM4rk/guardrails-review@main
+        with:
+          pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+          openrouter-key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/guardrails-review.yml` using `Questi0nM4rk/guardrails-review@main`
- Auto-triggers on PR open/reopen/sync
- Manual trigger via `/guardrails-review` comment on any PR

## Why this needs to merge first

GitHub Actions workflows must exist on the base branch (`main`) to have access to repository secrets. Once this merges, the bot will auto-review all subsequent PRs including the v1 rewrite (`refactor/extract-lang-config`).

## Requires

`OPENROUTER_KEY` secret set in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)