### PR TITLE
fix(allowlist): allow type: ignore[misc/arg-type] in test files

### DIFF
--- a/.suppression-allowlist
+++ b/.suppression-allowlist
@@ -70,3 +70,15 @@ languages/python\.py:\d+:import tomllib.*# type: ignore\[no-redef\]
 # ---------------------------------------------------------------------------
 languages/_registry\.py:\d+:.*# noqa: BLE001
 
+# ---------------------------------------------------------------------------
+# tests/ — type: ignore in test files
+# [misc]: Assigning to a frozen dataclass field in pytest.raises(AttributeError)
+#   blocks. Mypy sees this as a type error; we need the statement to exist at
+#   runtime so pytest can assert it raises. Not a real suppression — the test
+#   is verifying that the assignment fails.
+# [arg-type]: Passing deliberately wrong types (invalid Literals, **dict with
+#   mixed types) to test runtime validation or exercise all code paths.
+#   These are intentional bad-type probes, not production code suppressions.
+# ---------------------------------------------------------------------------
+tests/.*\.py:\d+:.*# type: ignore\[misc\]
+tests/.*\.py:\d+:.*# type: ignore\[arg-type\]


### PR DESCRIPTION
## Fix

Adds allowlist entries for `# type: ignore[misc]` and `# type: ignore[arg-type]` in test files.

### Why

The v2 frozen dataclass model tests include patterns like:

```python
with pytest.raises(AttributeError):
    entry.issue_count = 0  # type: ignore[misc]
```

The suppression is needed to satisfy mypy (assigning to a frozen field is a type error), but the statement must exist at runtime so pytest can assert it raises `AttributeError`. The `# type: ignore` is **not** silencing a real issue — it is enabling the test to exist.

Similarly, `# type: ignore[arg-type]` is used to pass deliberately invalid types (e.g. wrong `Literal` values) to exercise runtime validation paths.

guardrails-review flagged these 10 times as "Suppression comment without allowlist entry" on PR #57.

### Related

guardrails-review bug: bot approved despite finding 10 defects — fix in `guardrails-review/fix/agentic-approve-override`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)