### PR TITLE
fix(cli): detect git worktrees — .git can be a file not a directory

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,9 +4,9 @@ name: Check
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, feat/v2]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, feat/v2]
 
 jobs:
   lint:

--- a/src/ai_guardrails/cli.py
+++ b/src/ai_guardrails/cli.py
@@ -39,7 +39,7 @@ _CUSTOM_PLUGINS_DIR = _GLOBAL_CONFIG_DIR / "plugins"
 def _resolve_project_dir(project_dir: Path | None) -> Path:
     """Resolve and validate the project directory is a git repo."""
     resolved = (project_dir or Path.cwd()).resolve()
-    if not (resolved / ".git").is_dir():
+    if not (resolved / ".git").exists():
         raise SystemExit(
             f"Error: {resolved} is not a git repository. Run 'git init' first."
         )


### PR DESCRIPTION
## Summary

`_resolve_project_dir` checked `(project_dir / ".git").is_dir()` to validate a git repo. In a git worktree, `.git` is a **file** (pointing to the real `.git`), not a directory — so `is_dir()` returned `False` and every worktree was rejected as "not a git repository."

This caused the `validate-configs` pre-commit hook to fail in all phase worktrees, and prompted agents to consider `--no-verify` as a workaround. Fixed to `.exists()` which accepts both files and directories.

Also enables CI checks on PRs targeting `feat/v2` so phase branches get lint/test gates before merge.

## Fix

```python
# Before (fails in worktrees):
if not (resolved / ".git").is_dir():

# After (works for both normal repos and worktrees):
if not (resolved / ".git").exists():
```

## Test plan
- [ ] `ai-guardrails status` works inside a worktree
- [ ] Pre-commit `validate-configs` hook passes in worktrees
- [ ] Existing tests still pass