### PR TITLE
fix(init): gracefully fall back when EOFError during interactive prompts

### DIFF
--- a/src/ai_guardrails/pipelines/init_pipeline.py
+++ b/src/ai_guardrails/pipelines/init_pipeline.py
@@ -115,12 +115,15 @@ class InitPipeline:
         run_agent = not self._options.no_agent_instructions
 
         if self._options.interactive:
-            if run_hooks:
-                run_hooks = ask_yes_no("Install lefthook hooks?")
-            if run_ci:
-                run_ci = ask_yes_no("Generate CI workflow?")
-            if run_agent:
-                run_agent = ask_yes_no("Install Claude Code agent instructions?")
+            try:
+                if run_hooks:
+                    run_hooks = ask_yes_no("Install lefthook hooks?")
+                if run_ci:
+                    run_ci = ask_yes_no("Generate CI workflow?")
+                if run_agent:
+                    run_agent = ask_yes_no("Install Claude Code agent instructions?")
+            except EOFError:
+                pass  # non-TTY pipe with --interactive: use defaults
 
         if run_hooks:
             steps.append(SetupHooksStep())

--- a/tests/test_v1/pipelines/test_init_pipeline_interactive.py
+++ b/tests/test_v1/pipelines/test_init_pipeline_interactive.py
@@ -279,3 +279,20 @@ def test_init_pipeline_interactive_prompt_questions_are_descriptive(
     assert any("ci" in q or "workflow" in q for q in questions)
     # agent instructions question
     assert any("agent" in q or "claude" in q or "instruction" in q for q in questions)
+
+
+def test_init_pipeline_interactive_eof_falls_back_to_defaults(tmp_path: Path) -> None:
+    """If stdin closes (EOFError) during interactive prompts, fall back to defaults."""
+    options = InitOptions(interactive=True)
+    pipeline = _make_pipeline(options)
+
+    with patch(
+        "ai_guardrails.pipelines.init_pipeline.ask_yes_no", side_effect=EOFError
+    ):
+        results = _run(pipeline, tmp_path)
+
+    # Should not crash — falls back to running all steps
+    assert len(results) > 0
+    assert not any(
+        r.status == "error" and "EOFError" in (r.message or "") for r in results
+    )


### PR DESCRIPTION
## Problem

`--interactive` on a non-TTY pipe (e.g. `echo y | ai-guardrails init --interactive`) causes `input()` to raise `EOFError`, crashing the pipeline with an unhandled exception.

## Fix

Wrap all three `ask_yes_no()` calls in a single `try/except EOFError: pass`. On EOF, the pipeline continues with the current defaults (all steps enabled), which matches the non-interactive behavior.

## Test

`test_init_pipeline_interactive_eof_falls_back_to_defaults` — patches `ask_yes_no` to raise `EOFError` and asserts the pipeline runs without crashing.