### PR TITLE
feat(audit): audit log on check runs + report command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,4 +209,8 @@ warn_return_any = true
 warn_unused_ignores = true
 
 [dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-cov>=7.0.0",
+]
 type-check = ["pyright>=1.1.408"]

--- a/src/ai_guardrails/cli.py
+++ b/src/ai_guardrails/cli.py
@@ -19,6 +19,7 @@ from ai_guardrails.pipelines.check_pipeline import CheckOptions, CheckPipeline
 from ai_guardrails.pipelines.generate_pipeline import GenerateOptions, GeneratePipeline
 from ai_guardrails.pipelines.init_pipeline import InitOptions, InitPipeline
 from ai_guardrails.pipelines.install_pipeline import InstallOptions, InstallPipeline
+from ai_guardrails.pipelines.report_pipeline import ReportPipeline
 from ai_guardrails.pipelines.status_pipeline import StatusPipeline
 
 if TYPE_CHECKING:
@@ -198,6 +199,25 @@ def status(*, project_dir: Path | None = None) -> None:
     resolved = _resolve_project_dir(project_dir)
     custom_dir = _CUSTOM_PLUGINS_DIR if _CUSTOM_PLUGINS_DIR.is_dir() else None
     pipeline = StatusPipeline(data_dir=_DATA_DIR, custom_plugins_dir=custom_dir)
+    fm, runner, loader, console = _make_infra()
+    results = pipeline.run(
+        project_dir=resolved,
+        file_manager=fm,
+        command_runner=runner,
+        config_loader=loader,
+        console=console,
+    )
+    _print_results(results, console)
+
+
+@app.command
+def report(*, project_dir: Path | None = None) -> None:
+    """Show a summary of recent ai-guardrails check runs.
+
+    Reads .guardrails-audit.jsonl and prints the last 10 check run results.
+    """
+    resolved = _resolve_project_dir(project_dir)
+    pipeline = ReportPipeline()
     fm, runner, loader, console = _make_infra()
     results = pipeline.run(
         project_dir=resolved,

--- a/src/ai_guardrails/infra/file_manager.py
+++ b/src/ai_guardrails/infra/file_manager.py
@@ -64,3 +64,11 @@ class FileManager:
         if not link.exists():
             link.symlink_to(target)
         return None
+
+    def append_text(self, path: Path, text: str) -> str | None:
+        """Append text to a file (creates if absent). Dry-run returns description."""
+        if self.dry_run:
+            return f"would append to {path}"
+        with path.open("a", encoding="utf-8") as f:
+            f.write(text)
+        return None

--- a/src/ai_guardrails/pipelines/check_pipeline.py
+++ b/src/ai_guardrails/pipelines/check_pipeline.py
@@ -9,6 +9,8 @@ registry (it uses its own baseline file, not the exception allowlist).
 from __future__ import annotations
 
 from dataclasses import dataclass
+import datetime
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -80,4 +82,20 @@ class CheckPipeline:
         ]
 
         pipeline = Pipeline(steps=steps)
-        return pipeline.run(ctx)
+        results = pipeline.run(ctx)
+
+        check_result = next(
+            (r for r in results if r.status in ("ok", "error", "skip")), None
+        )
+        if check_result and check_result.status != "skip":
+            status = "ok" if check_result.status == "ok" else "error"
+            record = {
+                "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+                "command": "check",
+                "new_issues": sum(1 for r in results if r.status == "error"),
+                "status": status,
+            }
+            audit_path = project_dir / ".guardrails-audit.jsonl"
+            file_manager.append_text(audit_path, json.dumps(record) + "\n")
+
+        return results

--- a/src/ai_guardrails/pipelines/report_pipeline.py
+++ b/src/ai_guardrails/pipelines/report_pipeline.py
@@ -1,0 +1,44 @@
+"""ReportPipeline — show audit log summary."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai_guardrails.pipelines.base import Pipeline, PipelineContext
+from ai_guardrails.steps.report_step import ReportStep
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ai_guardrails.infra.command_runner import CommandRunner
+    from ai_guardrails.infra.config_loader import ConfigLoader
+    from ai_guardrails.infra.console import Console
+    from ai_guardrails.infra.file_manager import FileManager
+    from ai_guardrails.pipelines.base import StepResult
+
+
+class ReportPipeline:
+    """Displays audit log summary."""
+
+    def run(
+        self,
+        project_dir: Path,
+        file_manager: FileManager,
+        command_runner: CommandRunner,
+        config_loader: ConfigLoader,
+        console: Console,
+    ) -> list[StepResult]:
+        """Execute ReportStep within a pipeline context."""
+        ctx = PipelineContext(
+            project_dir=project_dir,
+            file_manager=file_manager,
+            command_runner=command_runner,
+            config_loader=config_loader,
+            console=console,
+            languages=[],
+            registry=None,
+            dry_run=False,
+            force=False,
+        )
+        pipeline = Pipeline(steps=[ReportStep()])
+        return pipeline.run(ctx)

--- a/src/ai_guardrails/steps/report_step.py
+++ b/src/ai_guardrails/steps/report_step.py
@@ -1,0 +1,52 @@
+"""ReportStep — reads .guardrails-audit.jsonl and prints a summary."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from ai_guardrails.pipelines.base import StepResult
+
+if TYPE_CHECKING:
+    from ai_guardrails.pipelines.base import PipelineContext
+
+_AUDIT_FILE = ".guardrails-audit.jsonl"
+_MAX_ROWS = 10
+
+
+class ReportStep:
+    """Reads the audit log and prints a summary of recent check runs."""
+
+    name = "report"
+
+    def validate(self, ctx: PipelineContext) -> list[str]:
+        """No preconditions required."""
+        return []
+
+    def execute(self, ctx: PipelineContext) -> StepResult:
+        """Read audit log and print last _MAX_ROWS entries."""
+        audit_path = ctx.project_dir / _AUDIT_FILE
+        if not audit_path.exists():
+            ctx.console.info("No audit log found. Run 'ai-guardrails check' first.")
+            return StepResult(status="ok", message="No audit log found.")
+
+        lines = audit_path.read_text(encoding="utf-8").splitlines()
+        rows = []
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                rows.append(json.loads(stripped))
+            except json.JSONDecodeError:
+                continue
+
+        recent = rows[-_MAX_ROWS:]
+        ctx.console.info(f"Last {len(recent)} check run(s):")
+        for row in recent:
+            ts = row.get("timestamp", "?")[:19]
+            status = row.get("status", "?")
+            new_issues = row.get("new_issues", 0)
+            ctx.console.info(f"  {ts}  {status:<6}  {new_issues} new issue(s)")
+
+        return StepResult(status="ok", message=f"Showed {len(recent)} audit record(s).")

--- a/tests/test_v1/conftest.py
+++ b/tests/test_v1/conftest.py
@@ -78,6 +78,14 @@ class FakeFileManager:
             self.symlinked.append((link, target))
         return None
 
+    def append_text(self, path: Path, text: str) -> str | None:
+        if self.dry_run:
+            return f"would append to {path}"
+        existing = self._files.get(path, "")
+        self._files[path] = existing + text
+        self.written.append((path, text))
+        return None
+
     def seed(self, path: Path, content: str) -> None:
         """Pre-populate a file for test setup."""
         self._files[path] = content

--- a/tests/test_v1/infra/test_file_manager.py
+++ b/tests/test_v1/infra/test_file_manager.py
@@ -140,3 +140,27 @@ def test_symlink_skips_existing(tmp_path: Path) -> None:
     assert result is None
     assert not link.is_symlink()
     assert link.read_text() == "existing content"
+
+
+def test_file_manager_append_text_creates_file(tmp_path: Path) -> None:
+    fm = FileManager()
+    p = tmp_path / "log.jsonl"
+    result = fm.append_text(p, "line1\n")
+    assert result is None
+    assert p.read_text() == "line1\n"
+
+
+def test_file_manager_append_text_appends(tmp_path: Path) -> None:
+    fm = FileManager()
+    p = tmp_path / "log.jsonl"
+    fm.append_text(p, "line1\n")
+    fm.append_text(p, "line2\n")
+    assert p.read_text() == "line1\nline2\n"
+
+
+def test_file_manager_append_text_dry_run(tmp_path: Path) -> None:
+    fm = FileManager(dry_run=True)
+    p = tmp_path / "log.jsonl"
+    result = fm.append_text(p, "line1\n")
+    assert result is not None
+    assert not p.exists()

--- a/tests/test_v1/pipelines/test_check_pipeline.py
+++ b/tests/test_v1/pipelines/test_check_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from ai_guardrails.infra.config_loader import ConfigLoader
@@ -93,3 +94,34 @@ def test_check_pipeline_with_explicit_baseline(tmp_path: Path) -> None:
     )
 
     assert isinstance(results, list)
+
+
+def test_check_pipeline_writes_audit_log(tmp_path: Path) -> None:
+    """After a successful check run the audit JSONL is written."""
+    runner = FakeCommandRunner()
+    runner.register(
+        ["uv", "run", "ruff", "check", "--output-format=json", str(tmp_path)],
+        returncode=0,
+        stdout="[]",
+    )
+
+    fm = FakeFileManager()
+    pipeline = _make_pipeline()
+    pipeline.run(
+        project_dir=tmp_path,
+        file_manager=fm,
+        command_runner=runner,
+        config_loader=ConfigLoader(),
+        console=FakeConsole(),
+    )
+
+    audit_path = tmp_path / ".guardrails-audit.jsonl"
+    # FakeFileManager.written records (path, text) tuples from append_text calls
+    written_paths = [p for p, _ in fm.written]
+    assert audit_path in written_paths
+    content = next(text for p, text in fm.written if p == audit_path)
+    record = json.loads(content.strip())
+    assert record["command"] == "check"
+    assert record["status"] in ("ok", "error")
+    assert "timestamp" in record
+    assert "new_issues" in record

--- a/tests/test_v1/steps/test_report_step.py
+++ b/tests/test_v1/steps/test_report_step.py
@@ -1,0 +1,102 @@
+"""Tests for ReportStep."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from ai_guardrails.infra.config_loader import ConfigLoader
+from ai_guardrails.pipelines.base import PipelineContext
+from ai_guardrails.steps.report_step import ReportStep
+from tests.test_v1.conftest import FakeCommandRunner, FakeConsole, FakeFileManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_ctx(tmp_path: Path, *, lines: list[str] | None = None) -> PipelineContext:
+    if lines is not None:
+        audit = tmp_path / ".guardrails-audit.jsonl"
+        audit.write_text("\n".join(lines) + "\n")
+    return PipelineContext(
+        project_dir=tmp_path,
+        file_manager=FakeFileManager(),
+        command_runner=FakeCommandRunner(),
+        config_loader=ConfigLoader(),
+        console=FakeConsole(),
+        languages=[],
+        registry=None,
+        dry_run=False,
+        force=False,
+    )
+
+
+def test_report_step_no_audit_file(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = ReportStep().execute(ctx)
+    assert result.status == "ok"
+    assert "No audit log" in result.message
+
+
+def test_report_step_shows_recent_runs(tmp_path: Path) -> None:
+    records = [
+        json.dumps(
+            {
+                "timestamp": "2026-03-07T12:00:00+00:00",
+                "status": "ok",
+                "new_issues": 0,
+            }
+        ),
+        json.dumps(
+            {
+                "timestamp": "2026-03-06T11:00:00+00:00",
+                "status": "error",
+                "new_issues": 2,
+            }
+        ),
+    ]
+    ctx = _make_ctx(tmp_path, lines=records)
+    result = ReportStep().execute(ctx)
+    assert result.status == "ok"
+    console: FakeConsole = ctx.console  # type: ignore[assignment]
+    assert any("2026-03-07" in txt for _, txt in console.messages)
+    assert any("error" in txt for _, txt in console.messages)
+
+
+def test_report_step_validate_returns_empty(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    assert ReportStep().validate(ctx) == []
+
+
+def test_report_step_skips_malformed_json_lines(tmp_path: Path) -> None:
+    records = [
+        json.dumps(
+            {"timestamp": "2026-03-07T10:00:00+00:00", "status": "ok", "new_issues": 0}
+        ),
+        "not-valid-json",
+        json.dumps(
+            {"timestamp": "2026-03-07T11:00:00+00:00", "status": "ok", "new_issues": 1}
+        ),
+    ]
+    ctx = _make_ctx(tmp_path, lines=records)
+    result = ReportStep().execute(ctx)
+    assert result.status == "ok"
+    assert "2" in result.message  # 2 valid records shown
+
+
+def test_report_step_limits_to_last_10_rows(tmp_path: Path) -> None:
+    records = [
+        json.dumps(
+            {
+                "timestamp": f"2026-03-0{i % 9 + 1}T10:00:00+00:00",
+                "status": "ok",
+                "new_issues": 0,
+                "command": "check",
+            }
+        )
+        for i in range(15)
+    ]
+    ctx = _make_ctx(tmp_path, lines=records)
+    result = ReportStep().execute(ctx)
+    assert result.status == "ok"
+    assert "10" in result.message

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,10 @@ dev = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
 type-check = [
     { name = "pyright" },
 ]
@@ -44,6 +48,10 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
 type-check = [{ name = "pyright", specifier = ">=1.1.408" }]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `FileManager.append_text(path, text)` — new method for append-only writes; `FakeFileManager` updated to match
- `CheckPipeline.run()` appends a JSONL record to `.guardrails-audit.jsonl` after every non-skip check run: `{timestamp, command, new_issues, status}`
- New `src/ai_guardrails/steps/report_step.py` — reads audit log, prints last 10 runs; graceful on missing file and malformed JSON lines
- New `src/ai_guardrails/pipelines/report_pipeline.py` — wraps `ReportStep`
- New `report` CLI command — `ai-guardrails report [--project-dir PATH]`

## Test plan
- [x] 3 tests for `FileManager.append_text` — create, append, dry-run
- [x] 5 tests for `ReportStep` — no log, shows runs, validate, malformed JSON tolerance, 10-row limit
- [x] 1 pipeline test — audit JSONL written after check run
- [x] 626 tests pass total
- [x] Ruff clean; pre-commit hooks caught and fixed SLF001, PLC0415, TC003

🤖 Generated with Claude Code