### PR TITLE
feat(phase-1): foundation — models, infra, config, utils, allow-comment

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,66 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "ai-guardrails",
+      "dependencies": {
+        "@commander-js/extra-typings": "^13.0.0",
+        "minimatch": "^10.0.0",
+        "smol-toml": "^1.5.1",
+        "zod": "^3.24.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.0",
+        "@types/bun": "latest",
+        "@types/minimatch": "^5.1.0",
+        "typescript": "^5.8.0",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@commander-js/extra-typings": ["@commander-js/extra-typings@13.1.0", "", { "peerDependencies": { "commander": "~13.1.0" } }, "sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg=="],
+
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/minimatch": ["@types/minimatch@5.1.2", "", {}, "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="],
+
+    "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,0 +1,41 @@
+import { join } from "node:path";
+import { parse as parseToml } from "smol-toml";
+import {
+  buildResolvedConfig,
+  type MachineConfig,
+  MachineConfigSchema,
+  type ProjectConfig,
+  ProjectConfigSchema,
+  type ResolvedConfig,
+} from "@/config/schema";
+import type { FileManager } from "@/infra/file-manager";
+
+export type { MachineConfig, ProjectConfig, ResolvedConfig };
+
+async function readTomlSafe(path: string, fm: FileManager): Promise<Record<string, unknown>> {
+  try {
+    const text = await fm.readText(path);
+    if (!text.trim()) return {};
+    return parseToml(text) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export async function loadMachineConfig(path: string, fm: FileManager): Promise<MachineConfig> {
+  const raw = await readTomlSafe(path, fm);
+  return MachineConfigSchema.parse(raw);
+}
+
+export async function loadProjectConfig(
+  projectDir: string,
+  fm: FileManager,
+): Promise<ProjectConfig> {
+  const path = join(projectDir, ".ai-guardrails", "config.toml");
+  const raw = await readTomlSafe(path, fm);
+  return ProjectConfigSchema.parse(raw);
+}
+
+export function resolveConfig(machine: MachineConfig, project: ProjectConfig): ResolvedConfig {
+  return buildResolvedConfig(machine, project);
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,99 @@
+import { minimatch } from "minimatch";
+import { z } from "zod";
+
+const IgnoreEntrySchema = z.object({
+  rule: z.string().regex(/^[\w-]+\/[\w\-.]+$/, "Format: linter/RULE_CODE"),
+  reason: z.string().min(1, "Reason is required"),
+});
+
+const MachineConfigSchema = z.object({
+  profile: z.enum(["strict", "standard", "minimal"]).default("standard"),
+  ignore: z.array(IgnoreEntrySchema).default([]),
+});
+
+export type MachineConfig = z.infer<typeof MachineConfigSchema>;
+
+export { MachineConfigSchema };
+
+const ConfigValuesSchema = z
+  .object({
+    line_length: z.number().int().min(60).max(200).default(88),
+    indent_width: z
+      .number()
+      .int()
+      .refine((v) => v === 2 || v === 4, {
+        message: "indent_width must be 2 or 4",
+      })
+      .default(4),
+    python_version: z
+      .string()
+      .regex(/^\d+\.\d+$/)
+      .optional(),
+  })
+  .passthrough();
+
+const AllowEntrySchema = z.object({
+  rule: z.string().regex(/^[\w-]+\/[\w\-.]+$/),
+  glob: z.string().min(1),
+  reason: z.string().min(1),
+});
+
+const ProjectConfigSchema = z.object({
+  profile: z.enum(["strict", "standard", "minimal"]).optional(),
+  config: ConfigValuesSchema.default({}),
+  ignore: z.array(IgnoreEntrySchema).default([]),
+  allow: z.array(AllowEntrySchema).default([]),
+});
+
+export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
+
+export { ProjectConfigSchema };
+
+export interface ResolvedConfig {
+  profile: "strict" | "standard" | "minimal";
+  ignore: ReadonlyArray<{ rule: string; reason: string }>;
+  allow: ReadonlyArray<{ rule: string; glob: string; reason: string }>;
+  values: {
+    line_length: number;
+    indent_width: number;
+    python_version?: string;
+    [key: string]: unknown;
+  };
+  ignoredRules: ReadonlySet<string>;
+  isAllowed(rule: string, filePath: string): boolean;
+}
+
+export function buildResolvedConfig(
+  machine: MachineConfig,
+  project: ProjectConfig,
+): ResolvedConfig {
+  const profile = project.profile ?? machine.profile;
+
+  // Merge ignores: machine → project, deduped by rule
+  const ignoreMap = new Map<string, string>();
+  for (const entry of [...machine.ignore, ...project.ignore]) {
+    ignoreMap.set(entry.rule, entry.reason);
+  }
+  const ignore = Array.from(ignoreMap.entries()).map(([rule, reason]) => ({
+    rule,
+    reason,
+  }));
+  const ignoredRules = new Set(ignore.map((e) => e.rule));
+  const allow = project.allow;
+  // Cast via unknown: Zod adds `| undefined` to optional fields but
+  // exactOptionalPropertyTypes treats `python_version?: string` as absent-or-string.
+  // The runtime values are compatible; the type mismatch is a Zod inference quirk.
+  const values = project.config as unknown as ResolvedConfig["values"];
+
+  return {
+    profile,
+    ignore,
+    allow,
+    values,
+    ignoredRules,
+    isAllowed(rule: string, filePath: string): boolean {
+      if (ignoredRules.has(rule)) return true;
+      return allow.some((entry) => entry.rule === rule && minimatch(filePath, entry.glob));
+    },
+  };
+}

--- a/src/hooks/allow-comment.ts
+++ b/src/hooks/allow-comment.ts
@@ -1,0 +1,39 @@
+export interface AllowComment {
+  rule: string;
+  reason: string;
+  line: number; // 1-indexed
+}
+
+// Matches: # ... ai-guardrails-allow: RULE "reason"
+//          // ... ai-guardrails-allow: RULE "reason"
+//          -- ... ai-guardrails-allow: RULE "reason"
+const ALLOW_PATTERN = /(?:#|\/\/|--)[ \t]*ai-guardrails-allow:[ \t]*([\w/-]+)[ \t]+"([^"]+)"/;
+
+/**
+ * Parse all inline allow comments from source lines.
+ * Returns one AllowComment per matched line.
+ * Lines without a valid allow comment (or without a quoted reason) are skipped.
+ */
+export function parseAllowComments(sourceLines: string[]): AllowComment[] {
+  const results: AllowComment[] = [];
+
+  for (let i = 0; i < sourceLines.length; i++) {
+    const line = sourceLines[i];
+    if (line === undefined) continue;
+
+    const match = ALLOW_PATTERN.exec(line);
+    if (!match) continue;
+
+    const rule = match[1]?.trim();
+    const reason = match[2]?.trim();
+    if (!rule || !reason) continue;
+
+    results.push({
+      rule,
+      reason,
+      line: i + 1, // 1-indexed
+    });
+  }
+
+  return results;
+}

--- a/src/infra/command-runner.ts
+++ b/src/infra/command-runner.ts
@@ -1,0 +1,40 @@
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface CommandRunner {
+  run(args: string[], opts?: { cwd?: string; timeout?: number }): Promise<RunResult>;
+}
+
+export class RealCommandRunner implements CommandRunner {
+  async run(args: string[], opts?: { cwd?: string; timeout?: number }): Promise<RunResult> {
+    const [cmd, ...rest] = args;
+    if (!cmd) {
+      return { stdout: "", stderr: "No command provided", exitCode: 1 };
+    }
+
+    const cwd = opts?.cwd;
+    const proc =
+      cwd !== undefined
+        ? Bun.spawn([cmd, ...rest], { cwd, stdout: "pipe", stderr: "pipe" })
+        : Bun.spawn([cmd, ...rest], { stdout: "pipe", stderr: "pipe" });
+
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+
+    if (opts?.timeout !== undefined) {
+      const timeoutPromise = new Promise<number>((_, reject) =>
+        setTimeout(() => reject(new Error("Command timed out")), opts.timeout),
+      );
+      const exitCode = await Promise.race([proc.exited, timeoutPromise]);
+      return { stdout, stderr, exitCode };
+    }
+
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  }
+}

--- a/src/infra/console.ts
+++ b/src/infra/console.ts
@@ -1,0 +1,35 @@
+export interface Console {
+  info(msg: string): void;
+  success(msg: string): void;
+  warning(msg: string): void;
+  error(msg: string): void;
+  step(msg: string): void;
+}
+
+const RESET = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const CYAN = "\x1b[36m";
+
+export class RealConsole implements Console {
+  info(msg: string): void {
+    process.stdout.write(`${msg}\n`);
+  }
+
+  success(msg: string): void {
+    process.stdout.write(`${GREEN}${msg}${RESET}\n`);
+  }
+
+  warning(msg: string): void {
+    process.stdout.write(`${YELLOW}${msg}${RESET}\n`);
+  }
+
+  error(msg: string): void {
+    process.stdout.write(`${RED}${msg}${RESET}\n`);
+  }
+
+  step(msg: string): void {
+    process.stdout.write(`${CYAN}${msg}${RESET}\n`);
+  }
+}

--- a/src/infra/file-manager.ts
+++ b/src/infra/file-manager.ts
@@ -1,0 +1,57 @@
+import { promises as fs } from "node:fs";
+import { Glob } from "bun";
+
+export interface FileManager {
+  readText(path: string): Promise<string>;
+  writeText(path: string, content: string): Promise<void>;
+  appendText(path: string, content: string): Promise<void>;
+  exists(path: string): Promise<boolean>;
+  mkdir(path: string, opts?: { parents?: boolean }): Promise<void>;
+  glob(pattern: string, cwd: string): Promise<string[]>;
+  isSymlink(path: string): Promise<boolean>;
+}
+
+export class RealFileManager implements FileManager {
+  async readText(path: string): Promise<string> {
+    return fs.readFile(path, "utf8");
+  }
+
+  async writeText(path: string, content: string): Promise<void> {
+    await fs.writeFile(path, content, "utf8");
+  }
+
+  async appendText(path: string, content: string): Promise<void> {
+    await fs.appendFile(path, content, "utf8");
+  }
+
+  async exists(path: string): Promise<boolean> {
+    try {
+      await fs.access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async mkdir(path: string, opts?: { parents?: boolean }): Promise<void> {
+    await fs.mkdir(path, { recursive: opts?.parents ?? false });
+  }
+
+  async glob(pattern: string, cwd: string): Promise<string[]> {
+    const g = new Glob(pattern);
+    const results: string[] = [];
+    for await (const file of g.scan({ cwd, absolute: false })) {
+      results.push(file);
+    }
+    return results;
+  }
+
+  async isSymlink(path: string): Promise<boolean> {
+    try {
+      const stat = await fs.lstat(path);
+      return stat.isSymbolicLink();
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/utils/fingerprint.ts
+++ b/src/utils/fingerprint.ts
@@ -1,0 +1,35 @@
+import type { LintIssue } from "@/models/lint-issue";
+import { computeFingerprint } from "@/models/lint-issue";
+
+const CONTEXT_LINES = 2;
+
+/**
+ * Compute a stable fingerprint for a lint issue using surrounding source lines.
+ * The fingerprint does not include the file path so it survives file moves.
+ */
+export function fingerprintIssue(
+  issue: Omit<LintIssue, "fingerprint">,
+  sourceLines: string[],
+): string {
+  // line is 1-indexed; convert to 0-indexed for array access
+  const lineIdx = issue.line - 1;
+  const lineContent = sourceLines[lineIdx] ?? "";
+
+  const contextBefore: string[] = [];
+  for (let i = Math.max(0, lineIdx - CONTEXT_LINES); i < lineIdx; i++) {
+    contextBefore.push(sourceLines[i] ?? "");
+  }
+
+  const contextAfter: string[] = [];
+  for (let i = lineIdx + 1; i <= Math.min(sourceLines.length - 1, lineIdx + CONTEXT_LINES); i++) {
+    contextAfter.push(sourceLines[i] ?? "");
+  }
+
+  return computeFingerprint({
+    rule: issue.rule,
+    file: issue.file,
+    lineContent,
+    contextBefore,
+    contextAfter,
+  });
+}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,31 @@
+import { createHash } from "node:crypto";
+
+export const HASH_PREFIX = "# ai-guardrails:sha256=";
+
+/**
+ * Compute a SHA-256 hash header for the given file body content.
+ * The hash covers the body text below the header line.
+ */
+export function makeHashHeader(content: string): string {
+  const hash = createHash("sha256").update(content).digest("hex");
+  return `${HASH_PREFIX}${hash}`;
+}
+
+/**
+ * Verify that a file's hash header matches its content.
+ * The file format is: `<header line>\n<body>`.
+ * Returns false if the header is missing or the hash does not match.
+ */
+export function verifyHash(fileContent: string): boolean {
+  const newlineIndex = fileContent.indexOf("\n");
+  if (newlineIndex === -1) return false;
+
+  const headerLine = fileContent.slice(0, newlineIndex);
+  if (!headerLine.startsWith(HASH_PREFIX)) return false;
+
+  const storedHash = headerLine.slice(HASH_PREFIX.length);
+  const body = fileContent.slice(newlineIndex + 1);
+  const expectedHash = createHash("sha256").update(body).digest("hex");
+
+  return storedHash === expectedHash;
+}

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import { loadMachineConfig, loadProjectConfig, resolveConfig } from "@/config/loader";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+describe("loadMachineConfig", () => {
+  test("loads and parses valid machine config from TOML", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(
+      "/machine.toml",
+      `profile = "strict"\n[[ignore]]\nrule = "ruff/E501"\nreason = "Too strict"\n`,
+    );
+    const config = await loadMachineConfig("/machine.toml", fm);
+    expect(config.profile).toBe("strict");
+    expect(config.ignore).toHaveLength(1);
+    expect(config.ignore[0]?.rule).toBe("ruff/E501");
+  });
+
+  test("returns defaults when file does not exist", async () => {
+    const fm = new FakeFileManager();
+    const config = await loadMachineConfig("/nonexistent.toml", fm);
+    expect(config.profile).toBe("standard");
+    expect(config.ignore).toEqual([]);
+  });
+
+  test("returns defaults for empty TOML file", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("/empty.toml", "");
+    const config = await loadMachineConfig("/empty.toml", fm);
+    expect(config.profile).toBe("standard");
+  });
+});
+
+describe("loadProjectConfig", () => {
+  test("loads project config from project directory", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(
+      "/proj/.ai-guardrails/config.toml",
+      `profile = "minimal"\n[config]\nline_length = 100\n`,
+    );
+    const config = await loadProjectConfig("/proj", fm);
+    expect(config.profile).toBe("minimal");
+    expect(config.config.line_length).toBe(100);
+  });
+
+  test("returns defaults when project config does not exist", async () => {
+    const fm = new FakeFileManager();
+    const config = await loadProjectConfig("/proj", fm);
+    expect(config.profile).toBeUndefined();
+    expect(config.ignore).toEqual([]);
+  });
+});
+
+describe("resolveConfig", () => {
+  test("project profile overrides machine profile", () => {
+    const resolved = resolveConfig(
+      { profile: "strict", ignore: [] },
+      { profile: "minimal", config: { line_length: 88, indent_width: 4 }, ignore: [], allow: [] },
+    );
+    expect(resolved.profile).toBe("minimal");
+  });
+
+  test("uses machine profile when project has none", () => {
+    const resolved = resolveConfig(
+      { profile: "strict", ignore: [] },
+      { config: { line_length: 88, indent_width: 4 }, ignore: [], allow: [] },
+    );
+    expect(resolved.profile).toBe("strict");
+  });
+
+  test("merges ignore lists from machine and project", () => {
+    const resolved = resolveConfig(
+      {
+        profile: "standard",
+        ignore: [{ rule: "ruff/E501", reason: "machine" }],
+      },
+      {
+        config: { line_length: 88, indent_width: 4 },
+        ignore: [{ rule: "ruff/D", reason: "project" }],
+        allow: [],
+      },
+    );
+    expect(resolved.ignore).toHaveLength(2);
+    const rules = resolved.ignore.map((i) => i.rule);
+    expect(rules).toContain("ruff/E501");
+    expect(rules).toContain("ruff/D");
+  });
+
+  test("project ignore overrides machine ignore reason for same rule", () => {
+    const resolved = resolveConfig(
+      {
+        profile: "standard",
+        ignore: [{ rule: "ruff/E501", reason: "machine reason" }],
+      },
+      {
+        config: { line_length: 88, indent_width: 4 },
+        ignore: [{ rule: "ruff/E501", reason: "project reason" }],
+        allow: [],
+      },
+    );
+    expect(resolved.ignore).toHaveLength(1);
+    expect(resolved.ignore[0]?.reason).toBe("project reason");
+  });
+
+  test("isAllowed returns true for globally ignored rule", () => {
+    const resolved = resolveConfig(
+      { profile: "standard", ignore: [{ rule: "ruff/E501", reason: "test" }] },
+      { config: { line_length: 88, indent_width: 4 }, ignore: [], allow: [] },
+    );
+    expect(resolved.isAllowed("ruff/E501", "src/foo.py")).toBe(true);
+  });
+
+  test("isAllowed returns false for non-ignored rule", () => {
+    const resolved = resolveConfig(
+      { profile: "standard", ignore: [] },
+      { config: { line_length: 88, indent_width: 4 }, ignore: [], allow: [] },
+    );
+    expect(resolved.isAllowed("ruff/E501", "src/foo.py")).toBe(false);
+  });
+
+  test("isAllowed returns true when rule matches glob allow entry", () => {
+    const resolved = resolveConfig(
+      { profile: "standard", ignore: [] },
+      {
+        config: { line_length: 88, indent_width: 4 },
+        ignore: [],
+        allow: [{ rule: "ruff/ARG002", glob: "tests/**/*.py", reason: "fixtures" }],
+      },
+    );
+    expect(resolved.isAllowed("ruff/ARG002", "tests/unit/foo.py")).toBe(true);
+    expect(resolved.isAllowed("ruff/ARG002", "src/foo.py")).toBe(false);
+  });
+
+  test("isAllowed is false for different rule matching allow glob", () => {
+    const resolved = resolveConfig(
+      { profile: "standard", ignore: [] },
+      {
+        config: { line_length: 88, indent_width: 4 },
+        ignore: [],
+        allow: [{ rule: "ruff/ARG002", glob: "tests/**/*.py", reason: "fixtures" }],
+      },
+    );
+    expect(resolved.isAllowed("ruff/E501", "tests/unit/foo.py")).toBe(false);
+  });
+
+  test("ignoredRules set contains all globally ignored rules", () => {
+    const resolved = resolveConfig(
+      {
+        profile: "standard",
+        ignore: [{ rule: "ruff/E501", reason: "test" }],
+      },
+      {
+        config: { line_length: 88, indent_width: 4 },
+        ignore: [{ rule: "ruff/D", reason: "project" }],
+        allow: [],
+      },
+    );
+    expect(resolved.ignoredRules.has("ruff/E501")).toBe(true);
+    expect(resolved.ignoredRules.has("ruff/D")).toBe(true);
+    expect(resolved.ignoredRules.has("ruff/W")).toBe(false);
+  });
+});

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { ZodError } from "zod";
+import { MachineConfigSchema, ProjectConfigSchema } from "@/config/schema";
+
+describe("MachineConfigSchema", () => {
+  test("parses valid machine config", () => {
+    const result = MachineConfigSchema.parse({
+      profile: "strict",
+      ignore: [{ rule: "ruff/E501", reason: "Too strict" }],
+    });
+    expect(result.profile).toBe("strict");
+    expect(result.ignore).toHaveLength(1);
+    expect(result.ignore[0]?.rule).toBe("ruff/E501");
+  });
+
+  test("defaults profile to standard when omitted", () => {
+    const result = MachineConfigSchema.parse({});
+    expect(result.profile).toBe("standard");
+  });
+
+  test("defaults ignore to empty array when omitted", () => {
+    const result = MachineConfigSchema.parse({});
+    expect(result.ignore).toEqual([]);
+  });
+
+  test("parses all valid profiles", () => {
+    expect(MachineConfigSchema.parse({ profile: "strict" }).profile).toBe("strict");
+    expect(MachineConfigSchema.parse({ profile: "standard" }).profile).toBe("standard");
+    expect(MachineConfigSchema.parse({ profile: "minimal" }).profile).toBe("minimal");
+  });
+
+  test("throws ZodError for invalid profile", () => {
+    expect(() => MachineConfigSchema.parse({ profile: "extreme" })).toThrow(ZodError);
+  });
+
+  test("throws ZodError for ignore entry without reason", () => {
+    expect(() =>
+      MachineConfigSchema.parse({
+        ignore: [{ rule: "ruff/E501" }],
+      }),
+    ).toThrow(ZodError);
+  });
+
+  test("throws ZodError for ignore entry with invalid rule format", () => {
+    expect(() =>
+      MachineConfigSchema.parse({
+        ignore: [{ rule: "E501-invalid", reason: "test" }],
+      }),
+    ).toThrow(ZodError);
+  });
+
+  test("throws ZodError for ignore entry with empty reason", () => {
+    expect(() =>
+      MachineConfigSchema.parse({
+        ignore: [{ rule: "ruff/E501", reason: "" }],
+      }),
+    ).toThrow(ZodError);
+  });
+});
+
+describe("ProjectConfigSchema", () => {
+  test("parses valid project config with all fields", () => {
+    const result = ProjectConfigSchema.parse({
+      profile: "minimal",
+      config: { line_length: 100, indent_width: 2 },
+      ignore: [{ rule: "ruff/D", reason: "No docstrings" }],
+      allow: [
+        {
+          rule: "ruff/ARG002",
+          glob: "tests/**/*.py",
+          reason: "pytest fixtures",
+        },
+      ],
+    });
+    expect(result.profile).toBe("minimal");
+    expect(result.config.line_length).toBe(100);
+    expect(result.ignore).toHaveLength(1);
+    expect(result.allow).toHaveLength(1);
+  });
+
+  test("profile is optional (undefined when omitted)", () => {
+    const result = ProjectConfigSchema.parse({});
+    expect(result.profile).toBeUndefined();
+  });
+
+  test("config defaults to empty object with schema defaults", () => {
+    const result = ProjectConfigSchema.parse({});
+    expect(result.config.line_length).toBe(88);
+    expect(result.config.indent_width).toBe(4);
+  });
+
+  test("ignore defaults to empty array", () => {
+    const result = ProjectConfigSchema.parse({});
+    expect(result.ignore).toEqual([]);
+  });
+
+  test("allow defaults to empty array", () => {
+    const result = ProjectConfigSchema.parse({});
+    expect(result.allow).toEqual([]);
+  });
+
+  test("throws ZodError for invalid profile", () => {
+    expect(() => ProjectConfigSchema.parse({ profile: "ultra" })).toThrow(ZodError);
+  });
+
+  test("throws ZodError for line_length below minimum", () => {
+    expect(() => ProjectConfigSchema.parse({ config: { line_length: 40 } })).toThrow(ZodError);
+  });
+
+  test("throws ZodError for line_length above maximum", () => {
+    expect(() => ProjectConfigSchema.parse({ config: { line_length: 300 } })).toThrow(ZodError);
+  });
+
+  test("throws ZodError for invalid indent_width", () => {
+    expect(() => ProjectConfigSchema.parse({ config: { indent_width: 3 } })).toThrow(ZodError);
+  });
+
+  test("python_version is optional", () => {
+    const result = ProjectConfigSchema.parse({
+      config: { python_version: "3.11" },
+    });
+    expect(result.config.python_version).toBe("3.11");
+  });
+
+  test("allow entry requires glob", () => {
+    expect(() =>
+      ProjectConfigSchema.parse({
+        allow: [{ rule: "ruff/E501", reason: "test" }],
+      }),
+    ).toThrow(ZodError);
+  });
+
+  test("passthrough allows unknown config keys", () => {
+    const result = ProjectConfigSchema.parse({
+      config: { unknown_tool_setting: 42 },
+    });
+    expect((result.config as Record<string, unknown>).unknown_tool_setting).toBe(42);
+  });
+});

--- a/tests/fakes/fake-command-runner.ts
+++ b/tests/fakes/fake-command-runner.ts
@@ -1,0 +1,21 @@
+import type { CommandRunner, RunResult } from "@/infra/command-runner";
+
+export class FakeCommandRunner implements CommandRunner {
+  readonly calls: string[][] = [];
+  private readonly responses = new Map<string, RunResult>();
+
+  register(args: string[], response: RunResult): void {
+    this.responses.set(args.join(" "), response);
+  }
+
+  async run(args: string[], _opts?: { cwd?: string; timeout?: number }): Promise<RunResult> {
+    this.calls.push(args);
+    return (
+      this.responses.get(args.join(" ")) ?? {
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      }
+    );
+  }
+}

--- a/tests/fakes/fake-console.ts
+++ b/tests/fakes/fake-console.ts
@@ -1,0 +1,29 @@
+import type { Console } from "@/infra/console";
+
+export class FakeConsole implements Console {
+  readonly infos: string[] = [];
+  readonly successes: string[] = [];
+  readonly warnings: string[] = [];
+  readonly errors: string[] = [];
+  readonly steps: string[] = [];
+
+  info(msg: string): void {
+    this.infos.push(msg);
+  }
+
+  success(msg: string): void {
+    this.successes.push(msg);
+  }
+
+  warning(msg: string): void {
+    this.warnings.push(msg);
+  }
+
+  error(msg: string): void {
+    this.errors.push(msg);
+  }
+
+  step(msg: string): void {
+    this.steps.push(msg);
+  }
+}

--- a/tests/fakes/fake-file-manager.ts
+++ b/tests/fakes/fake-file-manager.ts
@@ -1,0 +1,63 @@
+import type { FileManager } from "@/infra/file-manager";
+
+export class FakeFileManager implements FileManager {
+  private readonly files = new Map<string, string>();
+  readonly written: Array<[string, string]> = [];
+  readonly appended: Array<[string, string]> = [];
+
+  seed(path: string, content: string): void {
+    this.files.set(path, content);
+  }
+
+  async readText(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) {
+      throw new Error(`File not found: ${path}`);
+    }
+    return content;
+  }
+
+  async writeText(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+    this.written.push([path, content]);
+  }
+
+  async appendText(path: string, content: string): Promise<void> {
+    const existing = this.files.get(path) ?? "";
+    this.files.set(path, existing + content);
+    this.appended.push([path, content]);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return this.files.has(path);
+  }
+
+  async mkdir(_path: string, _opts?: { parents?: boolean }): Promise<void> {
+    // no-op for fake
+  }
+
+  async glob(pattern: string, _cwd: string): Promise<string[]> {
+    const results: string[] = [];
+    for (const key of this.files.keys()) {
+      if (matchesGlob(key, pattern)) {
+        results.push(key);
+      }
+    }
+    return results;
+  }
+
+  async isSymlink(_path: string): Promise<boolean> {
+    return false;
+  }
+}
+
+/** Simple glob matching for fake: supports * and ** wildcards */
+function matchesGlob(path: string, pattern: string): boolean {
+  // Convert glob pattern to regex
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "__DOUBLE_STAR__")
+    .replace(/\*/g, "[^/]*")
+    .replace(/__DOUBLE_STAR__/g, ".*");
+  return new RegExp(`^${escaped}$`).test(path);
+}

--- a/tests/hooks/allow-comment.test.ts
+++ b/tests/hooks/allow-comment.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { parseAllowComments } from "@/hooks/allow-comment";
+
+describe("parseAllowComments", () => {
+  test("parses Python/shell style # comment", () => {
+    const lines = ['x = 1  # ai-guardrails-allow: ruff/E501 "URL cannot be shortened"'];
+    const allows = parseAllowComments(lines);
+    expect(allows).toHaveLength(1);
+    expect(allows[0]?.rule).toBe("ruff/E501");
+    expect(allows[0]?.reason).toBe("URL cannot be shortened");
+    expect(allows[0]?.line).toBe(1);
+  });
+
+  test("parses TypeScript/JS // comment", () => {
+    const lines = ['const x = 1; // ai-guardrails-allow: biome/noExplicitAny "external API type"'];
+    const allows = parseAllowComments(lines);
+    expect(allows).toHaveLength(1);
+    expect(allows[0]?.rule).toBe("biome/noExplicitAny");
+    expect(allows[0]?.reason).toBe("external API type");
+    expect(allows[0]?.line).toBe(1);
+  });
+
+  test("parses Lua -- comment", () => {
+    const lines = ['local x = val -- ai-guardrails-allow: luacheck/W311 "loop variable shadowing"'];
+    const allows = parseAllowComments(lines);
+    expect(allows).toHaveLength(1);
+    expect(allows[0]?.rule).toBe("luacheck/W311");
+    expect(allows[0]?.reason).toBe("loop variable shadowing");
+    expect(allows[0]?.line).toBe(1);
+  });
+
+  test("returns empty array for lines with no allow comments", () => {
+    const lines = ["x = 1", "y = 2", "# just a regular comment"];
+    const allows = parseAllowComments(lines);
+    expect(allows).toHaveLength(0);
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(parseAllowComments([])).toHaveLength(0);
+  });
+
+  test("handles multiple allow comments in the same file", () => {
+    const lines = [
+      "x = 1",
+      '  # ai-guardrails-allow: ruff/E501 "long URL"',
+      "y = 2",
+      '  // ai-guardrails-allow: biome/noAny "external"',
+    ];
+    const allows = parseAllowComments(lines);
+    expect(allows).toHaveLength(2);
+    expect(allows[0]?.rule).toBe("ruff/E501");
+    expect(allows[0]?.line).toBe(2);
+    expect(allows[1]?.rule).toBe("biome/noAny");
+    expect(allows[1]?.line).toBe(4);
+  });
+
+  test("extracts rule and reason correctly", () => {
+    const lines = ['code  # ai-guardrails-allow: shellcheck/SC2086 "word splitting intentional"'];
+    const allows = parseAllowComments(lines);
+    expect(allows[0]?.rule).toBe("shellcheck/SC2086");
+    expect(allows[0]?.reason).toBe("word splitting intentional");
+  });
+
+  test("returns correct 1-indexed line numbers", () => {
+    const lines = ["line 1", "line 2", '# ai-guardrails-allow: ruff/E501 "test"', "line 4"];
+    const allows = parseAllowComments(lines);
+    expect(allows[0]?.line).toBe(3);
+  });
+
+  test("skips allow comment without a quoted reason", () => {
+    const lines = ["# ai-guardrails-allow: ruff/E501"];
+    const allows = parseAllowComments(lines);
+    expect(allows).toHaveLength(0);
+  });
+
+  test("handles allow comment as standalone comment line", () => {
+    const lines = ['# ai-guardrails-allow: ruff/T201 "CLI tool"'];
+    const allows = parseAllowComments(lines);
+    expect(allows).toHaveLength(1);
+    expect(allows[0]?.rule).toBe("ruff/T201");
+  });
+
+  test("trims whitespace around rule and reason", () => {
+    const lines = ['x = 1  #  ai-guardrails-allow:  ruff/E501  "reason here"'];
+    const allows = parseAllowComments(lines);
+    expect(allows).toHaveLength(1);
+    expect(allows[0]?.rule).toBe("ruff/E501");
+    expect(allows[0]?.reason).toBe("reason here");
+  });
+});

--- a/tests/infra/command-runner.test.ts
+++ b/tests/infra/command-runner.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+
+describe("FakeCommandRunner", () => {
+  test("returns registered response for matching args", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["ruff", "check", "."], {
+      stdout: "src/foo.py:1:1: E501",
+      stderr: "",
+      exitCode: 1,
+    });
+    const result = await runner.run(["ruff", "check", "."]);
+    expect(result.stdout).toBe("src/foo.py:1:1: E501");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("returns empty success for unregistered args", async () => {
+    const runner = new FakeCommandRunner();
+    const result = await runner.run(["unknown", "command"]);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("tracks all calls in order", async () => {
+    const runner = new FakeCommandRunner();
+    await runner.run(["cmd1"]);
+    await runner.run(["cmd2", "arg"]);
+    expect(runner.calls).toHaveLength(2);
+    expect(runner.calls[0]).toEqual(["cmd1"]);
+    expect(runner.calls[1]).toEqual(["cmd2", "arg"]);
+  });
+
+  test("can register multiple different commands", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["echo", "a"], { stdout: "a", stderr: "", exitCode: 0 });
+    runner.register(["echo", "b"], { stdout: "b", stderr: "", exitCode: 0 });
+    const a = await runner.run(["echo", "a"]);
+    const b = await runner.run(["echo", "b"]);
+    expect(a.stdout).toBe("a");
+    expect(b.stdout).toBe("b");
+  });
+});

--- a/tests/infra/file-manager.test.ts
+++ b/tests/infra/file-manager.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+describe("FakeFileManager", () => {
+  test("readText throws for missing file", async () => {
+    const fm = new FakeFileManager();
+    expect(fm.readText("/missing.txt")).rejects.toThrow("File not found: /missing.txt");
+  });
+
+  test("readText returns seeded content", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("/hello.txt", "hello world");
+    const content = await fm.readText("/hello.txt");
+    expect(content).toBe("hello world");
+  });
+
+  test("writeText stores content and tracks in written", async () => {
+    const fm = new FakeFileManager();
+    await fm.writeText("/out.txt", "content");
+    const content = await fm.readText("/out.txt");
+    expect(content).toBe("content");
+    expect(fm.written).toHaveLength(1);
+    expect(fm.written[0]).toEqual(["/out.txt", "content"]);
+  });
+
+  test("writeText overwrites existing content", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("/file.txt", "old");
+    await fm.writeText("/file.txt", "new");
+    expect(await fm.readText("/file.txt")).toBe("new");
+  });
+
+  test("appendText appends to existing content", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("/log.txt", "line1\n");
+    await fm.appendText("/log.txt", "line2\n");
+    expect(await fm.readText("/log.txt")).toBe("line1\nline2\n");
+  });
+
+  test("appendText creates file if not existing", async () => {
+    const fm = new FakeFileManager();
+    await fm.appendText("/new.txt", "content");
+    expect(await fm.readText("/new.txt")).toBe("content");
+  });
+
+  test("exists returns true for seeded files", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("/exists.txt", "");
+    expect(await fm.exists("/exists.txt")).toBe(true);
+  });
+
+  test("exists returns false for missing files", async () => {
+    const fm = new FakeFileManager();
+    expect(await fm.exists("/missing.txt")).toBe(false);
+  });
+
+  test("exists returns true after writeText", async () => {
+    const fm = new FakeFileManager();
+    await fm.writeText("/created.txt", "content");
+    expect(await fm.exists("/created.txt")).toBe(true);
+  });
+
+  test("glob matches files with pattern", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("src/foo.ts", "");
+    fm.seed("src/bar.ts", "");
+    fm.seed("tests/baz.ts", "");
+    const matches = await fm.glob("src/*.ts", "");
+    expect(matches).toContain("src/foo.ts");
+    expect(matches).toContain("src/bar.ts");
+    expect(matches).not.toContain("tests/baz.ts");
+  });
+
+  test("glob with ** matches nested paths", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("src/models/foo.ts", "");
+    fm.seed("src/infra/bar.ts", "");
+    fm.seed("README.md", "");
+    const matches = await fm.glob("src/**/*.ts", "");
+    expect(matches).toContain("src/models/foo.ts");
+    expect(matches).toContain("src/infra/bar.ts");
+    expect(matches).not.toContain("README.md");
+  });
+
+  test("isSymlink always returns false for fake", async () => {
+    const fm = new FakeFileManager();
+    expect(await fm.isSymlink("/any.txt")).toBe(false);
+  });
+
+  test("mkdir is a no-op", async () => {
+    const fm = new FakeFileManager();
+    await expect(fm.mkdir("/some/dir", { parents: true })).resolves.toBeUndefined();
+  });
+});

--- a/tests/models/baseline.test.ts
+++ b/tests/models/baseline.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { type BaselineEntry, classifyFingerprint, loadBaseline } from "@/models/baseline";
+
+function makeEntry(fingerprint: string): BaselineEntry {
+  return {
+    fingerprint,
+    rule: "ruff/E501",
+    linter: "ruff",
+    file: "src/foo.py",
+    line: 10,
+    message: "Line too long",
+    capturedAt: "2026-03-08T00:00:00.000Z",
+  };
+}
+
+describe("loadBaseline", () => {
+  test("builds map keyed by fingerprint", () => {
+    const entries = [makeEntry("abc123"), makeEntry("def456")];
+    const map = loadBaseline(entries);
+    expect(map.size).toBe(2);
+    expect(map.get("abc123")?.rule).toBe("ruff/E501");
+    expect(map.get("def456")?.linter).toBe("ruff");
+  });
+
+  test("returns empty map for empty array", () => {
+    const map = loadBaseline([]);
+    expect(map.size).toBe(0);
+  });
+
+  test("last entry wins for duplicate fingerprints", () => {
+    const a = { ...makeEntry("fp1"), line: 5 };
+    const b = { ...makeEntry("fp1"), line: 10 };
+    const map = loadBaseline([a, b]);
+    expect(map.size).toBe(1);
+    expect(map.get("fp1")?.line).toBe(10);
+  });
+});
+
+describe("classifyFingerprint", () => {
+  test("returns 'existing' when fingerprint is in baseline", () => {
+    const map = loadBaseline([makeEntry("known-fp")]);
+    expect(classifyFingerprint("known-fp", map)).toBe("existing");
+  });
+
+  test("returns 'new' when fingerprint is not in baseline", () => {
+    const map = loadBaseline([makeEntry("known-fp")]);
+    expect(classifyFingerprint("unknown-fp", map)).toBe("new");
+  });
+
+  test("returns 'new' for empty baseline", () => {
+    const map = loadBaseline([]);
+    expect(classifyFingerprint("any-fp", map)).toBe("new");
+  });
+});

--- a/tests/models/lint-issue.test.ts
+++ b/tests/models/lint-issue.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { computeFingerprint } from "@/models/lint-issue";
+
+describe("computeFingerprint", () => {
+  test("same input produces same hash", () => {
+    const opts = {
+      rule: "ruff/E501",
+      file: "src/foo.py",
+      lineContent: "  x = very_long_variable_name_that_exceeds_the_line_limit",
+      contextBefore: ["def foo():", "  # setup"],
+      contextAfter: ["  return x", ""],
+    };
+    const a = computeFingerprint(opts);
+    const b = computeFingerprint(opts);
+    expect(a).toBe(b);
+  });
+
+  test("different rule produces different hash", () => {
+    const base = {
+      file: "src/foo.py",
+      lineContent: "  x = 1",
+      contextBefore: [],
+      contextAfter: [],
+    };
+    const a = computeFingerprint({ ...base, rule: "ruff/E501" });
+    const b = computeFingerprint({ ...base, rule: "ruff/E302" });
+    expect(a).not.toBe(b);
+  });
+
+  test("different lineContent produces different hash", () => {
+    const base = {
+      rule: "ruff/E501",
+      file: "src/foo.py",
+      contextBefore: [],
+      contextAfter: [],
+    };
+    const a = computeFingerprint({ ...base, lineContent: "x = 1" });
+    const b = computeFingerprint({ ...base, lineContent: "x = 2" });
+    expect(a).not.toBe(b);
+  });
+
+  test("file path does not affect fingerprint", () => {
+    const base = {
+      rule: "ruff/E501",
+      lineContent: "  x = 1",
+      contextBefore: [],
+      contextAfter: [],
+    };
+    const a = computeFingerprint({ ...base, file: "src/foo.py" });
+    const b = computeFingerprint({ ...base, file: "src/bar.py" });
+    expect(a).toBe(b);
+  });
+
+  test("handles empty context arrays", () => {
+    const fp = computeFingerprint({
+      rule: "ruff/E501",
+      file: "src/foo.py",
+      lineContent: "x = 1",
+      contextBefore: [],
+      contextAfter: [],
+    });
+    expect(fp).toHaveLength(64); // SHA-256 hex
+  });
+
+  test("trims whitespace from lineContent for stability", () => {
+    const base = {
+      rule: "ruff/E501",
+      file: "src/foo.py",
+      contextBefore: [],
+      contextAfter: [],
+    };
+    const a = computeFingerprint({ ...base, lineContent: "  x = 1  " });
+    const b = computeFingerprint({ ...base, lineContent: "x = 1" });
+    expect(a).toBe(b);
+  });
+
+  test("different contextBefore produces different hash", () => {
+    const base = {
+      rule: "ruff/E501",
+      file: "src/foo.py",
+      lineContent: "x = 1",
+      contextAfter: [],
+    };
+    const a = computeFingerprint({ ...base, contextBefore: ["def foo():"] });
+    const b = computeFingerprint({ ...base, contextBefore: ["def bar():"] });
+    expect(a).not.toBe(b);
+  });
+
+  test("returns 64-character hex string", () => {
+    const fp = computeFingerprint({
+      rule: "ruff/E501",
+      file: "src/foo.py",
+      lineContent: "x = 1",
+      contextBefore: [],
+      contextAfter: [],
+    });
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/tests/models/step-result.test.ts
+++ b/tests/models/step-result.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { error, ok, skip, warn } from "@/models/step-result";
+
+describe("ok", () => {
+  test("sets status to ok", () => {
+    const result = ok("all good");
+    expect(result.status).toBe("ok");
+    expect(result.message).toBe("all good");
+  });
+});
+
+describe("error", () => {
+  test("sets status to error", () => {
+    const result = error("something failed");
+    expect(result.status).toBe("error");
+    expect(result.message).toBe("something failed");
+  });
+});
+
+describe("skip", () => {
+  test("sets status to skip", () => {
+    const result = skip("nothing to do");
+    expect(result.status).toBe("skip");
+    expect(result.message).toBe("nothing to do");
+  });
+});
+
+describe("warn", () => {
+  test("sets status to warn", () => {
+    const result = warn("check this");
+    expect(result.status).toBe("warn");
+    expect(result.message).toBe("check this");
+  });
+});

--- a/tests/utils/fingerprint.test.ts
+++ b/tests/utils/fingerprint.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { fingerprintIssue } from "@/utils/fingerprint";
+
+describe("fingerprintIssue", () => {
+  const sourceLines = [
+    "def foo():", // line 1
+    "  x = 1", // line 2
+    "  y = very_long_name", // line 3 — the flagged line
+    "  return y", // line 4
+    "", // line 5
+  ];
+
+  test("same issue produces same fingerprint", () => {
+    const issue = {
+      rule: "ruff/E501",
+      linter: "ruff",
+      file: "src/foo.py",
+      line: 3,
+      col: 1,
+      message: "Line too long",
+      severity: "error" as const,
+    };
+    const a = fingerprintIssue(issue, sourceLines);
+    const b = fingerprintIssue(issue, sourceLines);
+    expect(a).toBe(b);
+  });
+
+  test("different file but same content produces same fingerprint", () => {
+    const base = {
+      rule: "ruff/E501",
+      linter: "ruff",
+      line: 3,
+      col: 1,
+      message: "Line too long",
+      severity: "error" as const,
+    };
+    const a = fingerprintIssue({ ...base, file: "src/foo.py" }, sourceLines);
+    const b = fingerprintIssue({ ...base, file: "src/bar.py" }, sourceLines);
+    expect(a).toBe(b);
+  });
+
+  test("different rule produces different fingerprint", () => {
+    const base = {
+      linter: "ruff",
+      file: "src/foo.py",
+      line: 3,
+      col: 1,
+      message: "Line too long",
+      severity: "error" as const,
+    };
+    const a = fingerprintIssue({ ...base, rule: "ruff/E501" }, sourceLines);
+    const b = fingerprintIssue({ ...base, rule: "ruff/E302" }, sourceLines);
+    expect(a).not.toBe(b);
+  });
+
+  test("different line content produces different fingerprint", () => {
+    const issue = {
+      rule: "ruff/E501",
+      linter: "ruff",
+      file: "src/foo.py",
+      line: 3,
+      col: 1,
+      message: "Line too long",
+      severity: "error" as const,
+    };
+    const altLines = [...sourceLines];
+    altLines[2] = "  z = different_content";
+    const a = fingerprintIssue(issue, sourceLines);
+    const b = fingerprintIssue(issue, altLines);
+    expect(a).not.toBe(b);
+  });
+
+  test("returns a 64-char hex string", () => {
+    const issue = {
+      rule: "ruff/E501",
+      linter: "ruff",
+      file: "src/foo.py",
+      line: 3,
+      col: 1,
+      message: "Line too long",
+      severity: "error" as const,
+    };
+    const fp = fingerprintIssue(issue, sourceLines);
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("handles line at beginning of file (no contextBefore)", () => {
+    const issue = {
+      rule: "ruff/E501",
+      linter: "ruff",
+      file: "src/foo.py",
+      line: 1,
+      col: 1,
+      message: "Line too long",
+      severity: "error" as const,
+    };
+    // Should not throw
+    const fp = fingerprintIssue(issue, sourceLines);
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("handles line at end of file (no contextAfter)", () => {
+    const issue = {
+      rule: "ruff/E501",
+      linter: "ruff",
+      file: "src/foo.py",
+      line: 5,
+      col: 1,
+      message: "Line too long",
+      severity: "error" as const,
+    };
+    const fp = fingerprintIssue(issue, sourceLines);
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("handles empty source lines", () => {
+    const issue = {
+      rule: "ruff/E501",
+      linter: "ruff",
+      file: "src/foo.py",
+      line: 1,
+      col: 1,
+      message: "Line too long",
+      severity: "error" as const,
+    };
+    const fp = fingerprintIssue(issue, []);
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/tests/utils/hash.test.ts
+++ b/tests/utils/hash.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { HASH_PREFIX, makeHashHeader, verifyHash } from "@/utils/hash";
+
+describe("HASH_PREFIX", () => {
+  test("has correct value", () => {
+    expect(HASH_PREFIX).toBe("# ai-guardrails:sha256=");
+  });
+});
+
+describe("makeHashHeader", () => {
+  test("returns a line starting with the hash prefix", () => {
+    const header = makeHashHeader("some content");
+    expect(header).toStartWith(HASH_PREFIX);
+  });
+
+  test("returns a 64-char hex hash after the prefix", () => {
+    const header = makeHashHeader("some content");
+    const hash = header.slice(HASH_PREFIX.length);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("same content produces same header", () => {
+    const a = makeHashHeader("content");
+    const b = makeHashHeader("content");
+    expect(a).toBe(b);
+  });
+
+  test("different content produces different header", () => {
+    const a = makeHashHeader("content a");
+    const b = makeHashHeader("content b");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("verifyHash", () => {
+  test("roundtrip: makeHashHeader + verifyHash returns true", () => {
+    const body = "line1\nline2\nline3\n";
+    const header = makeHashHeader(body);
+    const fullFile = `${header}\n${body}`;
+    expect(verifyHash(fullFile)).toBe(true);
+  });
+
+  test("returns false for tampered content", () => {
+    const body = "original content\n";
+    const header = makeHashHeader(body);
+    const tampered = `${header}\ntampered content\n`;
+    expect(verifyHash(tampered)).toBe(false);
+  });
+
+  test("returns false for file with no hash header", () => {
+    const content = "no header here\n";
+    expect(verifyHash(content)).toBe(false);
+  });
+
+  test("returns false for file with empty content after header", () => {
+    const header = makeHashHeader("");
+    const fileWithJustHeader = `${header}\n`;
+    // body is "" so hash of "" should match
+    expect(verifyHash(fileWithJustHeader)).toBe(true);
+  });
+
+  test("handles multi-line file content correctly", () => {
+    const body = `${Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n")}\n`;
+    const header = makeHashHeader(body);
+    const fullFile = `${header}\n${body}`;
+    expect(verifyHash(fullFile)).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "Bundler",
+    "module": "Preserve",
     "moduleResolution": "Bundler",
     "lib": ["ESNext"],
     "types": ["bun-types"],


### PR DESCRIPTION
## Phase 1: Foundation

Implements all foundational types with no external tool calls. Core types + config system + fakes all tested.

### Added

**Models** (`src/models/`) — pre-existing stubs verified correct, tests written:
- `LintIssue` + `computeFingerprint` (SHA-256, file-path-stable)
- `BaselineEntry`, `BaselineStatus`, `loadBaseline`, `classifyFingerprint`
- `StepResult` discriminated union + `ok`/`error`/`skip`/`warn` helpers
- `AuditRecord` (type only)

**Infra** (`src/infra/`) — interfaces + real implementations:
- `FileManager` / `RealFileManager` — wraps `node:fs/promises` + `Bun.Glob`
- `CommandRunner` / `RealCommandRunner` — uses `Bun.spawn`
- `Console` / `RealConsole` — ANSI colours per level

**Fakes** (`tests/fakes/`) — in-memory test doubles:
- `FakeFileManager` — in-memory Map, `seed()`, tracks `written` + `appended`
- `FakeCommandRunner` — canned responses by args key, tracks `calls`
- `FakeConsole` — captures `infos`, `successes`, `warnings`, `errors`, `steps`

**Config** (`src/config/`):
- `schema.ts` — `MachineConfigSchema` + `ProjectConfigSchema` (Zod), `ResolvedConfig` interface, `buildResolvedConfig` with `minimatch`-based `isAllowed`
- `loader.ts` — `loadMachineConfig`, `loadProjectConfig` (smol-toml), `resolveConfig`

**Utils** (`src/utils/`):
- `hash.ts` — `HASH_PREFIX`, `makeHashHeader`, `verifyHash` (SHA-256 tamper detection)
- `fingerprint.ts` — `fingerprintIssue` using ±2 lines of source context

**Hooks** (`src/hooks/`):
- `allow-comment.ts` — `parseAllowComments` supporting `#`, `//`, `--` comment styles; requires quoted reason

**tsconfig fix**: `"module": "Preserve"` — `"Bundler"` is not valid for the `module` option in tsc 5.9.x (only for `moduleResolution`).

### Tests

98 tests across 10 files — all passing.

| File | Tests |
|------|-------|
| `tests/models/lint-issue.test.ts` | 8 |
| `tests/models/baseline.test.ts` | 6 |
| `tests/models/step-result.test.ts` | 4 |
| `tests/infra/file-manager.test.ts` | 13 |
| `tests/infra/command-runner.test.ts` | 4 |
| `tests/config/schema.test.ts` | 20 |
| `tests/config/loader.test.ts` | 14 |
| `tests/utils/hash.test.ts` | 10 |
| `tests/utils/fingerprint.test.ts` | 8 |
| `tests/hooks/allow-comment.test.ts` | 11 |

Refs: SPEC-001, SPEC-002, SPEC-007 Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)