### PR TITLE
feat(runners): TypeScript/JS runners — biome + tsc

### DIFF
--- a/src/runners/biome.ts
+++ b/src/runners/biome.ts
@@ -1,0 +1,157 @@
+import { resolve } from "node:path";
+import type { ResolvedConfig } from "@/config/schema";
+import type { CommandRunner } from "@/infra/command-runner";
+import type { LintIssue } from "@/models/lint-issue";
+import { computeFingerprint } from "@/models/lint-issue";
+import type { LinterRunner, RunOptions } from "@/runners/types";
+
+const BIOME_LINTER_ID = "biome";
+const BIOME_RULE_PREFIX = "biome/";
+
+// rdjson severity values from biome
+const SEVERITY_ERROR = "ERROR";
+
+interface RdjsonRange {
+  start: { line: number; character: number };
+  end: { line: number; character: number };
+}
+
+interface RdjsonDiagnostic {
+  location: {
+    path: { text: string };
+    range: RdjsonRange;
+  };
+  severity: string;
+  code: { value: string };
+  message: unknown; // may be string or object with content field
+}
+
+interface RdjsonOutput {
+  diagnostics: RdjsonDiagnostic[];
+}
+
+function extractMessage(message: unknown): string {
+  if (typeof message === "string") {
+    return message;
+  }
+  if (
+    typeof message === "object" &&
+    message !== null &&
+    "content" in message &&
+    typeof (message as { content: unknown }).content === "string"
+  ) {
+    return (message as { content: string }).content;
+  }
+  return String(message);
+}
+
+function isRdjsonOutput(value: unknown): value is RdjsonOutput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "diagnostics" in value &&
+    Array.isArray((value as RdjsonOutput).diagnostics)
+  );
+}
+
+export function parseBiomeRdjsonOutput(stdout: string, projectDir: string): LintIssue[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+
+  if (!isRdjsonOutput(parsed)) {
+    return [];
+  }
+
+  return parsed.diagnostics.map((diag) => {
+    const filePath = resolve(projectDir, diag.location.path.text);
+    const line = diag.location.range.start.line + 1;
+    const col = diag.location.range.start.character + 1;
+    const rule = BIOME_RULE_PREFIX + diag.code.value;
+    const message = extractMessage(diag.message);
+    const severity: "error" | "warning" = diag.severity === SEVERITY_ERROR ? "error" : "warning";
+    const fingerprint = computeFingerprint({
+      rule,
+      file: filePath,
+      lineContent: message,
+      contextBefore: [],
+      contextAfter: [],
+    });
+    return {
+      rule,
+      linter: BIOME_LINTER_ID,
+      file: filePath,
+      line,
+      col,
+      message,
+      severity,
+      fingerprint,
+    };
+  });
+}
+
+const BIOME_CONFIG_TEMPLATE: string = JSON.stringify(
+  {
+    $schema: "https://biomejs.dev/schemas/2.3.15/schema.json",
+    organizeImports: { enabled: true },
+    linter: {
+      enabled: true,
+      rules: {
+        recommended: true,
+        correctness: {
+          noUnusedVariables: "error",
+          noUnusedImports: "error",
+        },
+        style: {
+          noVar: "error",
+          useConst: "error",
+          useTemplate: "error",
+        },
+        suspicious: {
+          noExplicitAny: "error",
+          noConsole: "warn",
+        },
+      },
+    },
+    formatter: {
+      enabled: true,
+      indentStyle: "space",
+      indentWidth: 2,
+      lineWidth: 100,
+    },
+    javascript: {
+      formatter: {
+        quoteStyle: "double",
+        trailingCommas: "es5",
+      },
+    },
+  },
+  null,
+  2,
+);
+
+export const biomeRunner: LinterRunner = {
+  id: BIOME_LINTER_ID,
+  name: "Biome",
+  configFile: "biome.json",
+
+  async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
+    const result = await commandRunner.run(["biome", "--version"]);
+    return result.exitCode === 0;
+  },
+
+  async run({ projectDir, commandRunner }: RunOptions): Promise<LintIssue[]> {
+    const result = await commandRunner.run(["biome", "ci", "--reporter=rdjson", projectDir], {
+      cwd: projectDir,
+    });
+    // biome exits non-zero when issues are found — parse stdout regardless
+    return parseBiomeRdjsonOutput(result.stdout, projectDir);
+  },
+
+  generateConfig(_config: ResolvedConfig): string {
+    return BIOME_CONFIG_TEMPLATE;
+  },
+};

--- a/src/runners/tsc.ts
+++ b/src/runners/tsc.ts
@@ -1,0 +1,87 @@
+import { resolve } from "node:path";
+import type { ResolvedConfig } from "@/config/schema";
+import type { CommandRunner } from "@/infra/command-runner";
+import type { LintIssue } from "@/models/lint-issue";
+import { computeFingerprint } from "@/models/lint-issue";
+import type { LinterRunner, RunOptions } from "@/runners/types";
+
+const TSC_LINTER_ID = "tsc";
+const TSC_RULE_PREFIX = "tsc/";
+
+// Matches lines like: src/foo.ts(10,5): error TS2322: Type 'string' is not assignable...
+const TSC_LINE_PATTERN = /^(.+)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$/;
+
+interface TscMatch {
+  file: string;
+  line: number;
+  col: number;
+  tsCode: string;
+  message: string;
+}
+
+function parseTscLine(line: string): TscMatch | null {
+  const match = TSC_LINE_PATTERN.exec(line);
+  if (!match) return null;
+  const [, file, lineStr, colStr, , tsCode, message] = match;
+  if (!file || !lineStr || !colStr || !tsCode || !message) return null;
+  return {
+    file,
+    line: Number.parseInt(lineStr, 10),
+    col: Number.parseInt(colStr, 10),
+    tsCode,
+    message,
+  };
+}
+
+export function parseTscOutput(output: string, projectDir: string): LintIssue[] {
+  const issues: LintIssue[] = [];
+  for (const line of output.split("\n")) {
+    const parsed = parseTscLine(line);
+    if (!parsed) continue;
+    const filePath = resolve(projectDir, parsed.file);
+    const rule = TSC_RULE_PREFIX + parsed.tsCode;
+    const fingerprint = computeFingerprint({
+      rule,
+      file: filePath,
+      lineContent: parsed.message,
+      contextBefore: [],
+      contextAfter: [],
+    });
+    issues.push({
+      rule,
+      linter: TSC_LINTER_ID,
+      file: filePath,
+      line: parsed.line,
+      col: parsed.col,
+      message: parsed.message,
+      severity: "error",
+      fingerprint,
+    });
+  }
+  return issues;
+}
+
+export const tscRunner: LinterRunner = {
+  id: TSC_LINTER_ID,
+  name: "TypeScript Compiler",
+  configFile: null,
+
+  async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
+    const result = await commandRunner.run(["tsc", "--version"]);
+    return result.exitCode === 0;
+  },
+
+  async run({ projectDir, commandRunner }: RunOptions): Promise<LintIssue[]> {
+    const result = await commandRunner.run(["tsc", "--noEmit", "--pretty", "false"], {
+      cwd: projectDir,
+    });
+    // tsc exits non-zero when errors exist — parse stdout+stderr
+    const combined = `${result.stdout}\n${result.stderr}`;
+    return parseTscOutput(combined, projectDir);
+  },
+
+  generateConfig(_config: ResolvedConfig): null {
+    // tsconfig.json is user-managed — tsc needs no generated config
+    return null;
+  },
+};

--- a/src/runners/types.ts
+++ b/src/runners/types.ts
@@ -1,0 +1,20 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { CommandRunner } from "@/infra/command-runner";
+import type { FileManager } from "@/infra/file-manager";
+import type { LintIssue } from "@/models/lint-issue";
+
+export interface RunOptions {
+  projectDir: string;
+  config: ResolvedConfig;
+  commandRunner: CommandRunner;
+  fileManager: FileManager;
+}
+
+export interface LinterRunner {
+  readonly id: string;
+  readonly name: string;
+  readonly configFile: string | null;
+  isAvailable(commandRunner: CommandRunner): Promise<boolean>;
+  run(opts: RunOptions): Promise<LintIssue[]>;
+  generateConfig(config: ResolvedConfig): string | null;
+}

--- a/tests/fixtures/biome-rdjson-output.json
+++ b/tests/fixtures/biome-rdjson-output.json
@@ -1,0 +1,40 @@
+{
+  "diagnostics": [
+    {
+      "location": {
+        "path": { "text": "src/foo.ts" },
+        "range": {
+          "start": { "line": 9, "character": 3 },
+          "end": { "line": 9, "character": 14 }
+        }
+      },
+      "severity": "ERROR",
+      "code": { "value": "lint/correctness/noUnusedVariables" },
+      "message": "This variable is unused."
+    },
+    {
+      "location": {
+        "path": { "text": "src/bar.ts" },
+        "range": {
+          "start": { "line": 2, "character": 0 },
+          "end": { "line": 2, "character": 25 }
+        }
+      },
+      "severity": "WARNING",
+      "code": { "value": "lint/suspicious/noExplicitAny" },
+      "message": "Unexpected any. Specify a different type."
+    },
+    {
+      "location": {
+        "path": { "text": "src/baz.ts" },
+        "range": {
+          "start": { "line": 14, "character": 11 },
+          "end": { "line": 14, "character": 14 }
+        }
+      },
+      "severity": "ERROR",
+      "code": { "value": "lint/style/noVar" },
+      "message": "Use const or let instead of var."
+    }
+  ]
+}

--- a/tests/fixtures/tsc-output.txt
+++ b/tests/fixtures/tsc-output.txt
@@ -1,0 +1,3 @@
+src/foo.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.
+src/bar.ts(3,1): error TS2304: Cannot find name 'myVariable'.
+src/baz.ts(25,12): error TS7006: Parameter 'x' implicitly has an 'any' type.

--- a/tests/runners/biome.test.ts
+++ b/tests/runners/biome.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import type { ResolvedConfig } from "@/config/schema";
+import { biomeRunner, parseBiomeRdjsonOutput } from "@/runners/biome";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+const FIXTURE_PATH = resolve(import.meta.dir, "../fixtures/biome-rdjson-output.json");
+const PROJECT_DIR = "/project";
+
+const FIXTURE_JSON = await Bun.file(FIXTURE_PATH).text();
+
+function makeConfig(overrides?: Partial<ResolvedConfig>): ResolvedConfig {
+  return {
+    profile: "standard",
+    ignore: [],
+    allow: [],
+    values: { line_length: 100, indent_width: 2 },
+    ignoredRules: new Set(),
+    isAllowed: () => false,
+    ...overrides,
+  };
+}
+
+describe("parseBiomeRdjsonOutput", () => {
+  test("returns correct LintIssue[] from fixture", () => {
+    const issues = parseBiomeRdjsonOutput(FIXTURE_JSON, PROJECT_DIR);
+    expect(issues).toHaveLength(3);
+
+    const first = issues[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+    expect(first.rule).toBe("biome/lint/correctness/noUnusedVariables");
+    expect(first.linter).toBe("biome");
+    expect(first.file).toBe("/project/src/foo.ts");
+    expect(first.line).toBe(10); // 0-indexed 9 → 1-indexed 10
+    expect(first.col).toBe(4); // 0-indexed 3 → 1-indexed 4
+    expect(first.message).toBe("This variable is unused.");
+    expect(first.severity).toBe("error");
+    expect(first.fingerprint).toHaveLength(64);
+  });
+
+  test("returns [] for empty diagnostics array", () => {
+    const issues = parseBiomeRdjsonOutput('{"diagnostics":[]}', PROJECT_DIR);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("converts 0-indexed lines to 1-indexed", () => {
+    const json = JSON.stringify({
+      diagnostics: [
+        {
+          location: {
+            path: { text: "src/foo.ts" },
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+          },
+          severity: "ERROR",
+          code: { value: "lint/style/noVar" },
+          message: "Use const or let instead of var.",
+        },
+      ],
+    });
+    const issues = parseBiomeRdjsonOutput(json, PROJECT_DIR);
+    const issue = issues[0];
+    expect(issue).toBeDefined();
+    if (!issue) return;
+    expect(issue.line).toBe(1);
+    expect(issue.col).toBe(1);
+  });
+
+  test("resolves relative paths to absolute", () => {
+    const json = JSON.stringify({
+      diagnostics: [
+        {
+          location: {
+            path: { text: "src/nested/file.ts" },
+            range: { start: { line: 5, character: 2 }, end: { line: 5, character: 10 } },
+          },
+          severity: "ERROR",
+          code: { value: "lint/correctness/noUnusedVariables" },
+          message: "Unused.",
+        },
+      ],
+    });
+    const issues = parseBiomeRdjsonOutput(json, "/my/project");
+    const issue = issues[0];
+    expect(issue).toBeDefined();
+    if (!issue) return;
+    expect(issue.file).toBe("/my/project/src/nested/file.ts");
+  });
+
+  test("maps WARNING severity to warning", () => {
+    const issues = parseBiomeRdjsonOutput(FIXTURE_JSON, PROJECT_DIR);
+    const warning = issues.find((i) => i.rule === "biome/lint/suspicious/noExplicitAny");
+    expect(warning).toBeDefined();
+    if (!warning) return;
+    expect(warning.severity).toBe("warning");
+  });
+
+  test("maps ERROR severity to error", () => {
+    const issues = parseBiomeRdjsonOutput(FIXTURE_JSON, PROJECT_DIR);
+    const error = issues.find((i) => i.rule === "biome/lint/correctness/noUnusedVariables");
+    expect(error).toBeDefined();
+    if (!error) return;
+    expect(error.severity).toBe("error");
+  });
+
+  test("returns [] for malformed JSON", () => {
+    const issues = parseBiomeRdjsonOutput("not valid json", PROJECT_DIR);
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("biomeRunner.run", () => {
+  test("uses --reporter=rdjson flag", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["biome", "ci", "--reporter=rdjson", PROJECT_DIR], {
+      stdout: FIXTURE_JSON,
+      stderr: "",
+      exitCode: 1, // biome exits non-zero when issues found
+    });
+
+    const issues = await biomeRunner.run({
+      projectDir: PROJECT_DIR,
+      config: makeConfig(),
+      commandRunner: runner,
+      fileManager: new FakeFileManager(),
+    });
+
+    expect(runner.calls[0]).toEqual(["biome", "ci", "--reporter=rdjson", PROJECT_DIR]);
+    expect(issues).toHaveLength(3);
+  });
+
+  test("parses stdout regardless of non-zero exit code", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["biome", "ci", "--reporter=rdjson", PROJECT_DIR], {
+      stdout: FIXTURE_JSON,
+      stderr: "some stderr",
+      exitCode: 2,
+    });
+
+    const issues = await biomeRunner.run({
+      projectDir: PROJECT_DIR,
+      config: makeConfig(),
+      commandRunner: runner,
+      fileManager: new FakeFileManager(),
+    });
+
+    expect(issues).toHaveLength(3);
+  });
+});
+
+describe("biomeRunner.isAvailable", () => {
+  test("returns true when biome --version exits 0", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["biome", "--version"], { stdout: "biome 2.0.0", stderr: "", exitCode: 0 });
+    const result = await biomeRunner.isAvailable(runner);
+    expect(result).toBe(true);
+  });
+
+  test("returns false when biome --version exits non-zero", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["biome", "--version"], { stdout: "", stderr: "not found", exitCode: 127 });
+    const result = await biomeRunner.isAvailable(runner);
+    expect(result).toBe(false);
+  });
+});
+
+describe("biomeRunner.generateConfig", () => {
+  test("returns non-null biome.json string", () => {
+    const config = makeConfig();
+    const output = biomeRunner.generateConfig(config);
+    expect(output).not.toBeNull();
+    expect(typeof output).toBe("string");
+  });
+
+  test("returned string is valid JSON", () => {
+    const config = makeConfig();
+    const output = biomeRunner.generateConfig(config);
+    expect(output).not.toBeNull();
+    if (!output) return;
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  test("generated config includes $schema", () => {
+    const config = makeConfig();
+    const output = biomeRunner.generateConfig(config);
+    expect(output).not.toBeNull();
+    if (!output) return;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed.$schema).toBeDefined();
+  });
+});

--- a/tests/runners/tsc.test.ts
+++ b/tests/runners/tsc.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import type { ResolvedConfig } from "@/config/schema";
+import { parseTscOutput, tscRunner } from "@/runners/tsc";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+const FIXTURE_PATH = resolve(import.meta.dir, "../fixtures/tsc-output.txt");
+const PROJECT_DIR = "/project";
+
+const FIXTURE_TEXT = await Bun.file(FIXTURE_PATH).text();
+
+function makeConfig(overrides?: Partial<ResolvedConfig>): ResolvedConfig {
+  return {
+    profile: "standard",
+    ignore: [],
+    allow: [],
+    values: { line_length: 100, indent_width: 2 },
+    ignoredRules: new Set(),
+    isAllowed: () => false,
+    ...overrides,
+  };
+}
+
+describe("parseTscOutput", () => {
+  test("returns correct LintIssue[] from fixture", () => {
+    const issues = parseTscOutput(FIXTURE_TEXT, PROJECT_DIR);
+    expect(issues).toHaveLength(3);
+
+    const first = issues[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+    expect(first.rule).toBe("tsc/TS2322");
+    expect(first.linter).toBe("tsc");
+    expect(first.file).toBe("/project/src/foo.ts");
+    expect(first.line).toBe(10);
+    expect(first.col).toBe(5);
+    expect(first.message).toBe("Type 'string' is not assignable to type 'number'.");
+    expect(first.severity).toBe("error");
+    expect(first.fingerprint).toHaveLength(64);
+  });
+
+  test("returns [] for clean output", () => {
+    const issues = parseTscOutput("", PROJECT_DIR);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("handles multi-line errors by skipping non-matching lines", () => {
+    const text = [
+      "src/foo.ts(5,3): error TS2322: Type 'string' is not assignable to type 'number'.",
+      "  5 | const x: number = 'hello';", // continuation line — should be skipped
+      "    |   ~~~~~~~~~~~~~~~~~~~",
+      "src/bar.ts(10,1): error TS2304: Cannot find name 'foo'.",
+    ].join("\n");
+    const issues = parseTscOutput(text, PROJECT_DIR);
+    expect(issues).toHaveLength(2);
+  });
+
+  test("maps all tsc errors to error severity", () => {
+    const issues = parseTscOutput(FIXTURE_TEXT, PROJECT_DIR);
+    for (const issue of issues) {
+      expect(issue.severity).toBe("error");
+    }
+  });
+
+  test("prefixes rule with tsc/TS", () => {
+    const issues = parseTscOutput(FIXTURE_TEXT, PROJECT_DIR);
+    const second = issues[1];
+    expect(second).toBeDefined();
+    if (!second) return;
+    expect(second.rule).toBe("tsc/TS2304");
+  });
+
+  test("resolves file path relative to projectDir", () => {
+    const issues = parseTscOutput(FIXTURE_TEXT, "/my/project");
+    const first = issues[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+    expect(first.file).toBe("/my/project/src/foo.ts");
+  });
+});
+
+describe("tscRunner.run", () => {
+  test("uses --noEmit --pretty false flags", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["tsc", "--noEmit", "--pretty", "false"], {
+      stdout: FIXTURE_TEXT,
+      stderr: "",
+      exitCode: 1, // tsc exits non-zero on errors
+    });
+
+    const issues = await tscRunner.run({
+      projectDir: PROJECT_DIR,
+      config: makeConfig(),
+      commandRunner: runner,
+      fileManager: new FakeFileManager(),
+    });
+
+    expect(runner.calls[0]).toEqual(["tsc", "--noEmit", "--pretty", "false"]);
+    expect(issues).toHaveLength(3);
+  });
+
+  test("parses stdout and stderr combined for error lines", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["tsc", "--noEmit", "--pretty", "false"], {
+      stdout: "",
+      stderr: FIXTURE_TEXT,
+      exitCode: 1,
+    });
+
+    const issues = await tscRunner.run({
+      projectDir: PROJECT_DIR,
+      config: makeConfig(),
+      commandRunner: runner,
+      fileManager: new FakeFileManager(),
+    });
+
+    expect(issues).toHaveLength(3);
+  });
+
+  test("returns [] when no errors", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["tsc", "--noEmit", "--pretty", "false"], {
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const issues = await tscRunner.run({
+      projectDir: PROJECT_DIR,
+      config: makeConfig(),
+      commandRunner: runner,
+      fileManager: new FakeFileManager(),
+    });
+
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("tscRunner.isAvailable", () => {
+  test("returns true when tsc --version exits 0", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["tsc", "--version"], { stdout: "Version 5.8.0", stderr: "", exitCode: 0 });
+    const result = await tscRunner.isAvailable(runner);
+    expect(result).toBe(true);
+  });
+
+  test("returns false when tsc --version exits non-zero", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register(["tsc", "--version"], { stdout: "", stderr: "not found", exitCode: 127 });
+    const result = await tscRunner.isAvailable(runner);
+    expect(result).toBe(false);
+  });
+});
+
+describe("tscRunner.generateConfig", () => {
+  test("returns null (tsconfig.json is user-managed)", () => {
+    const config = makeConfig();
+    const result = tscRunner.generateConfig(config);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## TypeScript/JS Linter Runners

Implements biome and tsc runners per SPEC-003.

### Added
- `src/runners/types.ts` — `LinterRunner` + `RunOptions` interfaces
- `src/runners/biome.ts` — biome rdjson parser (NOT json reporter — experimental)
- `src/runners/tsc.ts` — tsc text/regex parser
- Fixture files and unit tests for both (26 tests)

### Notes
- biome: uses `--reporter=rdjson` (stable), NOT `--reporter=json` (experimental)
- biome: exits non-zero on findings — stdout parsed regardless of exit code
- biome: rdjson lines are 0-indexed, converted to 1-indexed in LintIssue
- tsc: no JSON output, regex on stderr+stdout text
- tsc: `generateConfig` returns `null` — tsconfig.json is user-managed
- malformed JSON from biome returns `[]` (graceful degradation)

Refs: SPEC-003, SPEC-008

🤖 Generated with [Claude Code](https://claude.com/claude-code)