### PR TITLE
fix(lint): correct biome.json — use 1.9.4 schema and organizeImports key

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,12 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
+  },
+  "organizeImports": {
+    "enabled": false
   },
   "linter": {
     "enabled": true,
@@ -32,14 +35,6 @@
     "formatter": {
       "quoteStyle": "double",
       "trailingCommas": "all"
-    }
-  },
-  "assist": {
-    "enabled": true,
-    "actions": {
-      "source": {
-        "organizeImports": "off"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Previous fix (PR #79) used biome 2.x `assist` key syntax, but the project pins `@biomejs/biome@^1.9.0` (installed as 1.9.4)
- In biome 1.9.4, the correct top-level key is `organizeImports`, not `assist`
- Also corrects the `$schema` URL from `2.3.15` to `1.9.4`
- `bun run lint` (which runs local 1.9.4) now passes cleanly with 57 files

## Changes

- `biome.json`: schema `2.3.15` → `1.9.4`, replaced `assist.actions.source.organizeImports` with `organizeImports.enabled: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)