### PR TITLE
feat(phase-3): language plugins, config generators, and agent-rules autodetection

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,13 +2,13 @@ pre-commit:
   commands:
     ts-format-and-stage:
       glob: "*.{ts,tsx,js,jsx}"
-      run: biome check --write {staged_files} && git add {staged_files}
+      run: ./node_modules/.bin/biome check --write {staged_files} && git add {staged_files}
       stage_fixed: true
       priority: 1
 
     biome-lint:
       glob: "*.{ts,tsx,js,jsx}"
-      run: biome check {staged_files}
+      run: ./node_modules/.bin/biome check {staged_files}
       fail_text: "Biome lint/format errors found"
       priority: 2
 

--- a/src/generators/agent-rules.ts
+++ b/src/generators/agent-rules.ts
@@ -1,0 +1,153 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { FileManager } from "@/infra/file-manager";
+import type { ConfigGenerator } from "@/generators/types";
+
+/** AI tool detection results */
+export interface DetectedAgentTools {
+  claude: boolean;
+  cursor: boolean;
+  windsurf: boolean;
+  copilot: boolean;
+  cline: boolean;
+  aider: boolean;
+}
+
+/** Detect which AI agent tools are configured in the project */
+export async function detectAgentTools(
+  projectDir: string,
+  fileManager: FileManager,
+): Promise<DetectedAgentTools> {
+  // Check for files known to exist within each tool's directory, or the config file directly
+  const [claudeSettings, claudeMd, cursorRules, cursorDir, windsurf, copilot, cline, aider] =
+    await Promise.all([
+      fileManager.exists(`${projectDir}/.claude/settings.json`),
+      fileManager.exists(`${projectDir}/.claude/CLAUDE.md`),
+      fileManager.exists(`${projectDir}/.cursorrules`),
+      fileManager.exists(`${projectDir}/.cursor/rules`),
+      fileManager.exists(`${projectDir}/.windsurfrules`),
+      fileManager.exists(`${projectDir}/.github/copilot-instructions.md`),
+      fileManager.exists(`${projectDir}/.clinerules`),
+      fileManager.exists(`${projectDir}/.aider.conf.yml`),
+    ]);
+
+  // Check for any file under .cursor/rules/ — glob against absolute paths
+  const cursorRulesFiles = await fileManager.glob("**/.cursor/rules/**", projectDir);
+
+  return {
+    claude: claudeSettings || claudeMd,
+    cursor: cursorRules || cursorDir || cursorRulesFiles.length > 0,
+    windsurf,
+    copilot,
+    cline,
+    aider,
+  };
+}
+
+const BASE_RULES = `# AI Agent Rules
+
+## Core Principles
+
+- Never push directly to main — always open a PR
+- Never commit secrets, credentials, or .env files
+- Run tests before committing: all tests must pass
+- Fix ALL review findings including nitpicks
+- Never batch-resolve review threads without reading each one
+
+## Git Workflow
+
+- Conventional commit messages: feat:, fix:, refactor:, chore:, test:, docs:
+- Create feature branches: git checkout -b feat/<name>
+- Keep commits focused — one logical change per commit
+
+## Code Quality
+
+- No any — use unknown + type narrowing at boundaries
+- No non-null assertions (!) — handle undefined explicitly
+- No commented-out code — delete it or open an issue
+- No TODO without an issue reference
+
+## Security
+
+- Never log secrets, tokens, or passwords
+- Never eval() user input
+- Never trust user-provided paths without sanitization
+`;
+
+const CLAUDE_ADDITIONS = `
+## Claude Code Specific
+
+- Read CLAUDE.md at the start of each session
+- Use PreToolUse hooks — they protect configs and catch dangerous commands
+- Never disable the hook system to bypass restrictions
+- The deny list in .claude/settings.json exists for safety — don't circumvent it
+`;
+
+const CURSOR_ADDITIONS = `
+## Cursor Specific
+
+- Follow the project's existing code style — don't reformat arbitrarily
+- Check existing tests before adding new ones — avoid duplication
+- Prefer editing existing files over creating new ones
+`;
+
+const WINDSURF_ADDITIONS = `
+## Windsurf Specific
+
+- Follow the project's existing code style
+- Check for existing utilities before implementing new ones
+- Run the test suite before marking a task complete
+`;
+
+const COPILOT_ADDITIONS = `
+## GitHub Copilot Specific
+
+- This project uses strict linting — suggestions must pass lint and typecheck
+- Follow conventional commit format for all commit messages
+- Check existing patterns in the codebase before suggesting new abstractions
+`;
+
+const CLINE_ADDITIONS = `
+## Cline Specific
+
+- Always read existing code before making changes
+- Prefer minimal diffs — change only what is necessary
+- Verify tests pass after each change
+`;
+
+const AIDER_ADDITIONS = `
+## Aider Specific
+
+- Use conventional commit messages (aider formats these automatically)
+- Keep changes focused — avoid unrelated edits in the same session
+- Run the test suite to verify changes before ending the session
+`;
+
+/** Symlink targets for each AI tool's rules file */
+export const AGENT_SYMLINKS: Readonly<Record<string, string>> = {
+  cursor: ".cursorrules",
+  windsurf: ".windsurfrules",
+  copilot: ".github/copilot-instructions.md",
+  cline: ".clinerules",
+} as const;
+
+/** Build the combined rules content for a specific agent tool */
+export function buildAgentRules(tool: keyof DetectedAgentTools): string {
+  const additions: Partial<Record<keyof DetectedAgentTools, string>> = {
+    claude: CLAUDE_ADDITIONS,
+    cursor: CURSOR_ADDITIONS,
+    windsurf: WINDSURF_ADDITIONS,
+    copilot: COPILOT_ADDITIONS,
+    cline: CLINE_ADDITIONS,
+    aider: AIDER_ADDITIONS,
+  };
+  const extra = additions[tool] ?? "";
+  return BASE_RULES + extra;
+}
+
+export const agentRulesGenerator: ConfigGenerator = {
+  id: "agent-rules",
+  configFile: ".ai-guardrails/agent-rules/base.md",
+  generate(_config: ResolvedConfig): string {
+    return BASE_RULES;
+  },
+};

--- a/src/generators/biome.ts
+++ b/src/generators/biome.ts
@@ -1,0 +1,54 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { ConfigGenerator } from "@/generators/types";
+
+function renderBiomeJson(config: ResolvedConfig): string {
+  const lineWidth = config.values.line_length ?? 100;
+  const indentWidth = config.values.indent_width ?? 2;
+  return JSON.stringify(
+    {
+      $schema: "https://biomejs.dev/schemas/1.9.4/schema.json",
+      organizeImports: { enabled: true },
+      linter: {
+        enabled: true,
+        rules: {
+          recommended: true,
+          correctness: {
+            noUnusedVariables: "error",
+            noUnusedImports: "error",
+          },
+          style: {
+            noVar: "error",
+            useConst: "error",
+            useTemplate: "error",
+          },
+          suspicious: {
+            noExplicitAny: "error",
+            noConsole: "warn",
+          },
+        },
+      },
+      formatter: {
+        enabled: true,
+        indentStyle: "space",
+        indentWidth,
+        lineWidth,
+      },
+      javascript: {
+        formatter: {
+          quoteStyle: "double",
+          trailingCommas: "es5",
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+export const biomeGenerator: ConfigGenerator = {
+  id: "biome",
+  configFile: "biome.json",
+  generate(config: ResolvedConfig): string {
+    return renderBiomeJson(config);
+  },
+};

--- a/src/generators/claude-settings.ts
+++ b/src/generators/claude-settings.ts
@@ -1,0 +1,35 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { ConfigGenerator } from "@/generators/types";
+
+interface ClaudeSettings {
+  permissions: {
+    deny: string[];
+  };
+}
+
+function renderClaudeSettings(_config: ResolvedConfig): string {
+  const settings: ClaudeSettings = {
+    permissions: {
+      deny: [
+        "Bash(git push*)",
+        "Bash(git push --force*)",
+        "Bash(rm -rf /*)",
+        "Bash(sudo rm -rf*)",
+        "Bash(chmod -R 777*)",
+        "Bash(curl * | bash)",
+        "Bash(wget * | bash)",
+        "Bash(eval $(*))",
+        "Bash(python -c*import os*system*)",
+      ],
+    },
+  };
+  return JSON.stringify(settings, null, 2);
+}
+
+export const claudeSettingsGenerator: ConfigGenerator = {
+  id: "claude-settings",
+  configFile: ".claude/settings.json",
+  generate(config: ResolvedConfig): string {
+    return renderClaudeSettings(config);
+  },
+};

--- a/src/generators/codespell.ts
+++ b/src/generators/codespell.ts
@@ -1,0 +1,20 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { ConfigGenerator } from "@/generators/types";
+import { makeHashHeader } from "@/utils/hash";
+
+function renderCodespellrc(_config: ResolvedConfig): string {
+  const content = `[codespell]
+skip = .git,*.lock,*.baseline,node_modules,.venv,venv,dist,build
+quiet-level = 2
+`;
+  const header = makeHashHeader(content);
+  return `${header}\n${content}`;
+}
+
+export const codespellGenerator: ConfigGenerator = {
+  id: "codespell",
+  configFile: ".codespellrc",
+  generate(config: ResolvedConfig): string {
+    return renderCodespellrc(config);
+  },
+};

--- a/src/generators/editorconfig.ts
+++ b/src/generators/editorconfig.ts
@@ -1,0 +1,36 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { ConfigGenerator } from "@/generators/types";
+import { makeHashHeader } from "@/utils/hash";
+
+function renderEditorconfig(_config: ResolvedConfig): string {
+  const content = `root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 88
+
+[*.{ts,js,tsx,jsx,json,yaml,yml,toml,md}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.go]
+indent_style = tab
+`;
+  const header = makeHashHeader(content);
+  return `${header}\n${content}`;
+}
+
+export const editorconfigGenerator: ConfigGenerator = {
+  id: "editorconfig",
+  configFile: ".editorconfig",
+  generate(config: ResolvedConfig): string {
+    return renderEditorconfig(config);
+  },
+};

--- a/src/generators/lefthook.ts
+++ b/src/generators/lefthook.ts
@@ -1,0 +1,102 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { ConfigGenerator } from "@/generators/types";
+import type { LanguagePlugin } from "@/languages/types";
+
+function renderLefthookYml(activePluginIds: ReadonlySet<string>): string {
+  const hasPython = activePluginIds.has("python");
+  const hasTs = activePluginIds.has("typescript");
+
+  const formatAndStageGlob = buildFormatGlob(hasPython, hasTs);
+
+  const pythonSection = hasPython
+    ? `
+    ruff-fix:
+      glob: "*.py"
+      run: ruff check --fix {staged_files} && git add {staged_files}
+      stage_fixed: true
+      priority: 1
+`
+    : "";
+
+  const tsSection = hasTs
+    ? `
+    biome-fix:
+      glob: "*.{ts,tsx,js,jsx}"
+      run: biome check --write {staged_files} && git add {staged_files}
+      stage_fixed: true
+      priority: 1
+`
+    : "";
+
+  return `pre-commit:
+  commands:
+${formatAndStageGlob}${pythonSection}${tsSection}
+    gitleaks:
+      run: gitleaks protect --staged --no-banner
+      fail_text: "Potential secrets detected"
+      priority: 2
+
+    codespell:
+      glob: "*.{ts,md,txt,yaml,yml,toml,json,py,go,rs}"
+      exclude: "tests/fixtures/.*"
+      run: codespell --check-filenames {staged_files}
+      fail_text: "Spell errors found"
+      priority: 2
+
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}
+      fail_text: "Markdown lint errors found"
+      priority: 2
+
+    no-commits-to-main:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$branch" = "main" ]; then
+          echo "Direct commits to main are not allowed"
+          exit 1
+        fi
+      fail_text: "Do not commit directly to main"
+      priority: 2
+
+commit-msg:
+  commands:
+    conventional:
+      run: grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?:" {1}
+      fail_text: "Commit message must follow Conventional Commits format"
+`;
+}
+
+function buildFormatGlob(hasPython: boolean, hasTs: boolean): string {
+  if (!hasPython && !hasTs) return "";
+  const exts: string[] = [];
+  if (hasTs) exts.push("ts", "tsx", "js", "jsx");
+  if (hasPython) exts.push("py");
+  const glob = exts.length === 1 ? `*.${exts[0]}` : `*.{${exts.join(",")}}`;
+  return `    format-and-stage:
+      glob: "${glob}"
+      run: echo "Format step — configure per language above"
+      priority: 1
+`;
+}
+
+/**
+ * Generate a lefthook.yml tailored to the active language plugins.
+ * Callers must pass active plugin ids resolved from detectLanguages().
+ */
+export function generateLefthookConfig(
+  _config: ResolvedConfig,
+  activePlugins: readonly LanguagePlugin[],
+): string {
+  const ids = new Set(activePlugins.map((p) => p.id));
+  return renderLefthookYml(ids);
+}
+
+export const lefthookGenerator: ConfigGenerator = {
+  id: "lefthook",
+  configFile: "lefthook.yml",
+  generate(_config: ResolvedConfig): string {
+    // Default: no language awareness — use generateLefthookConfig for language-aware output
+    return renderLefthookYml(new Set());
+  },
+};

--- a/src/generators/markdownlint.ts
+++ b/src/generators/markdownlint.ts
@@ -1,0 +1,21 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { ConfigGenerator } from "@/generators/types";
+
+function renderMarkdownlintJsonc(_config: ResolvedConfig): string {
+  // Note: no hash header — jsonc comments would be stripped by JSON parsers
+  return `{
+  "default": true,
+  "MD013": { "line_length": 120, "tables": false, "code_blocks": false },
+  "MD033": false,
+  "MD041": false
+}
+`;
+}
+
+export const markdownlintGenerator: ConfigGenerator = {
+  id: "markdownlint",
+  configFile: ".markdownlint.jsonc",
+  generate(config: ResolvedConfig): string {
+    return renderMarkdownlintJsonc(config);
+  },
+};

--- a/src/generators/registry.ts
+++ b/src/generators/registry.ts
@@ -1,0 +1,21 @@
+import { agentRulesGenerator } from "@/generators/agent-rules";
+import { biomeGenerator } from "@/generators/biome";
+import { claudeSettingsGenerator } from "@/generators/claude-settings";
+import { codespellGenerator } from "@/generators/codespell";
+import { editorconfigGenerator } from "@/generators/editorconfig";
+import { lefthookGenerator } from "@/generators/lefthook";
+import { markdownlintGenerator } from "@/generators/markdownlint";
+import { ruffGenerator } from "@/generators/ruff";
+import type { ConfigGenerator } from "@/generators/types";
+
+/** All built-in config generators */
+export const ALL_GENERATORS: readonly ConfigGenerator[] = [
+  ruffGenerator,
+  biomeGenerator,
+  editorconfigGenerator,
+  markdownlintGenerator,
+  codespellGenerator,
+  lefthookGenerator,
+  claudeSettingsGenerator,
+  agentRulesGenerator,
+];

--- a/src/generators/ruff.ts
+++ b/src/generators/ruff.ts
@@ -1,0 +1,80 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { ConfigGenerator } from "@/generators/types";
+import { makeHashHeader } from "@/utils/hash";
+
+function renderRuffToml(config: ResolvedConfig): string {
+  const lineLength = config.values.line_length ?? 88;
+  const indentWidth = config.values.indent_width ?? 4;
+  const content = `target-version = "py311"
+line-length = ${lineLength}
+indent-width = ${indentWidth}
+fix = false
+unsafe-fixes = false
+
+[lint]
+select = ["ALL"]
+
+ignore = [
+  # --- Formatter conflicts ---
+  "W191", "E111", "E114", "E117", "D206", "D300",
+  "Q000", "Q001", "Q002", "Q003", "COM812", "COM819",
+  "ISC001", "ISC002",
+  # --- Redundant with pyright ---
+  "ANN",
+  # --- Docstrings (opt-in) ---
+  "D",
+  # --- Development markers ---
+  "FIX001", "FIX002", "TD",
+  # --- High false-positive ---
+  "ERA001", "CPY001", "INP001", "T201",
+  "EM101", "EM102", "TRY003", "S101",
+]
+
+[lint.per-file-ignores]
+"tests/**/*.py" = ["ARG001", "ARG002", "PLR2004"]
+"**/__init__.py" = ["F401"]
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.flake8-type-checking]
+strict = true
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
+[lint.isort]
+force-single-line = false
+force-sort-within-sections = true
+combine-as-imports = true
+split-on-trailing-comma = true
+force-to-top = ["__future__"]
+required-imports = ["from __future__ import annotations"]
+
+[lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[lint.mccabe]
+max-complexity = 10
+
+[lint.pylint]
+max-args = 5
+max-branches = 10
+max-locals = 10
+max-statements = 30
+
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "lf"
+`;
+  const header = makeHashHeader(content);
+  return `${header}\n${content}`;
+}
+
+export const ruffGenerator: ConfigGenerator = {
+  id: "ruff",
+  configFile: "ruff.toml",
+  generate(config: ResolvedConfig): string {
+    return renderRuffToml(config);
+  },
+};

--- a/src/generators/types.ts
+++ b/src/generators/types.ts
@@ -1,0 +1,10 @@
+import type { ResolvedConfig } from "@/config/schema";
+
+export interface ConfigGenerator {
+  /** Stable identifier: "ruff", "biome", "editorconfig", etc. */
+  readonly id: string;
+  /** Filename to write, relative to project root */
+  readonly configFile: string;
+  /** Generate config file content from resolved config */
+  generate(config: ResolvedConfig): string;
+}

--- a/src/languages/cpp.ts
+++ b/src/languages/cpp.ts
@@ -1,0 +1,20 @@
+import { clangTidyRunner } from "@/runners/clang-tidy";
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const cppPlugin: LanguagePlugin = {
+  id: "cpp",
+  name: "C/C++",
+
+  async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
+    if (await fileManager.exists(`${projectDir}/CMakeLists.txt`)) return true;
+    const cppFiles = await fileManager.glob("**/*.cpp", projectDir);
+    if (cppFiles.length > 0) return true;
+    const cFiles = await fileManager.glob("**/*.c", projectDir);
+    return cFiles.length > 0;
+  },
+
+  runners(): LinterRunner[] {
+    return [clangTidyRunner];
+  },
+};

--- a/src/languages/dotnet.ts
+++ b/src/languages/dotnet.ts
@@ -1,0 +1,19 @@
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const dotnetPlugin: LanguagePlugin = {
+  id: "dotnet",
+  name: ".NET",
+
+  async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
+    const csprojFiles = await fileManager.glob("**/*.csproj", projectDir);
+    if (csprojFiles.length > 0) return true;
+    const slnFiles = await fileManager.glob("**/*.sln", projectDir);
+    return slnFiles.length > 0;
+  },
+
+  runners(): LinterRunner[] {
+    // dotnet-build runner is a stub — no implementation yet
+    return [];
+  },
+};

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -1,0 +1,16 @@
+import { golangciLintRunner } from "@/runners/golangci-lint";
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const goPlugin: LanguagePlugin = {
+  id: "go",
+  name: "Go",
+
+  async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
+    return fileManager.exists(`${projectDir}/go.mod`);
+  },
+
+  runners(): LinterRunner[] {
+    return [golangciLintRunner];
+  },
+};

--- a/src/languages/lua.ts
+++ b/src/languages/lua.ts
@@ -1,0 +1,17 @@
+import { seleneRunner } from "@/runners/selene";
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const luaPlugin: LanguagePlugin = {
+  id: "lua",
+  name: "Lua",
+
+  async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
+    const luaFiles = await fileManager.glob("**/*.lua", projectDir);
+    return luaFiles.length > 0;
+  },
+
+  runners(): LinterRunner[] {
+    return [seleneRunner];
+  },
+};

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1,0 +1,19 @@
+import { pyrightRunner } from "@/runners/pyright";
+import { ruffRunner } from "@/runners/ruff";
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const pythonPlugin: LanguagePlugin = {
+  id: "python",
+  name: "Python",
+
+  async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
+    if (await fileManager.exists(`${projectDir}/pyproject.toml`)) return true;
+    const pyFiles = await fileManager.glob("**/*.py", projectDir);
+    return pyFiles.length > 0;
+  },
+
+  runners(): LinterRunner[] {
+    return [ruffRunner, pyrightRunner];
+  },
+};

--- a/src/languages/registry.ts
+++ b/src/languages/registry.ts
@@ -1,0 +1,42 @@
+import type { FileManager } from "@/infra/file-manager";
+import { cppPlugin } from "@/languages/cpp";
+import { dotnetPlugin } from "@/languages/dotnet";
+import { goPlugin } from "@/languages/go";
+import { luaPlugin } from "@/languages/lua";
+import { pythonPlugin } from "@/languages/python";
+import { rustPlugin } from "@/languages/rust";
+import { shellPlugin } from "@/languages/shell";
+import { typescriptPlugin } from "@/languages/typescript";
+import { universalPlugin } from "@/languages/universal";
+import type { LanguagePlugin } from "@/languages/types";
+
+/** All built-in language plugins, in detection priority order. Universal is always last. */
+export const ALL_PLUGINS: readonly LanguagePlugin[] = [
+  pythonPlugin,
+  typescriptPlugin,
+  rustPlugin,
+  goPlugin,
+  shellPlugin,
+  cppPlugin,
+  dotnetPlugin,
+  luaPlugin,
+  universalPlugin,
+];
+
+/**
+ * Detect which languages are present in the project.
+ * Returns active plugins in priority order.
+ * Universal plugin is always included.
+ */
+export async function detectLanguages(
+  projectDir: string,
+  fileManager: FileManager,
+): Promise<LanguagePlugin[]> {
+  const results = await Promise.all(
+    ALL_PLUGINS.map(async (plugin) => ({
+      plugin,
+      active: await plugin.detect({ projectDir, fileManager }),
+    })),
+  );
+  return results.filter((r) => r.active).map((r) => r.plugin);
+}

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -1,0 +1,16 @@
+import { clippyRunner } from "@/runners/clippy";
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const rustPlugin: LanguagePlugin = {
+  id: "rust",
+  name: "Rust",
+
+  async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
+    return fileManager.exists(`${projectDir}/Cargo.toml`);
+  },
+
+  runners(): LinterRunner[] {
+    return [clippyRunner];
+  },
+};

--- a/src/languages/shell.ts
+++ b/src/languages/shell.ts
@@ -1,0 +1,22 @@
+import { shellcheckRunner } from "@/runners/shellcheck";
+import { shfmtRunner } from "@/runners/shfmt";
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const shellPlugin: LanguagePlugin = {
+  id: "shell",
+  name: "Shell",
+
+  async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
+    const shFiles = await fileManager.glob("**/*.sh", projectDir);
+    if (shFiles.length > 0) return true;
+    const bashFiles = await fileManager.glob("**/*.bash", projectDir);
+    if (bashFiles.length > 0) return true;
+    const zshFiles = await fileManager.glob("**/*.zsh", projectDir);
+    return zshFiles.length > 0;
+  },
+
+  runners(): LinterRunner[] {
+    return [shellcheckRunner, shfmtRunner];
+  },
+};

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -1,0 +1,18 @@
+import type { FileManager } from "@/infra/file-manager";
+import type { LinterRunner } from "@/runners/types";
+
+export interface DetectOptions {
+  projectDir: string;
+  fileManager: FileManager;
+}
+
+export interface LanguagePlugin {
+  /** Stable identifier: "python", "typescript", "rust", etc. */
+  readonly id: string;
+  /** Human-readable name */
+  readonly name: string;
+  /** Return true if this language is present in the project */
+  detect(opts: DetectOptions): Promise<boolean>;
+  /** Runners to use when this language is active */
+  runners(): LinterRunner[];
+}

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1,0 +1,21 @@
+import { biomeRunner } from "@/runners/biome";
+import { tscRunner } from "@/runners/tsc";
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const typescriptPlugin: LanguagePlugin = {
+  id: "typescript",
+  name: "TypeScript/JS",
+
+  async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
+    if (await fileManager.exists(`${projectDir}/package.json`)) return true;
+    const tsFiles = await fileManager.glob("**/*.ts", projectDir);
+    if (tsFiles.length > 0) return true;
+    const jsFiles = await fileManager.glob("**/*.js", projectDir);
+    return jsFiles.length > 0;
+  },
+
+  runners(): LinterRunner[] {
+    return [biomeRunner, tscRunner];
+  },
+};

--- a/src/languages/universal.ts
+++ b/src/languages/universal.ts
@@ -1,0 +1,18 @@
+import { codespellRunner } from "@/runners/codespell";
+import { markdownlintRunner } from "@/runners/markdownlint";
+import type { LinterRunner } from "@/runners/types";
+import type { DetectOptions, LanguagePlugin } from "@/languages/types";
+
+export const universalPlugin: LanguagePlugin = {
+  id: "universal",
+  name: "Universal",
+
+  /** Universal plugin is always active */
+  async detect(_opts: DetectOptions): Promise<boolean> {
+    return true;
+  },
+
+  runners(): LinterRunner[] {
+    return [codespellRunner, markdownlintRunner];
+  },
+};

--- a/tests/generators/__snapshots__/biome.test.ts.snap
+++ b/tests/generators/__snapshots__/biome.test.ts.snap
@@ -1,0 +1,41 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`biomeGenerator output matches snapshot 1`] = `
+"{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
+      },
+      "style": {
+        "noVar": "error",
+        "useConst": "error",
+        "useTemplate": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noConsole": "warn"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5"
+    }
+  }
+}"
+`;

--- a/tests/generators/__snapshots__/lefthook.test.ts.snap
+++ b/tests/generators/__snapshots__/lefthook.test.ts.snap
@@ -1,0 +1,97 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`generateLefthookConfig output matches snapshot for python + typescript 1`] = `
+"pre-commit:
+  commands:
+    format-and-stage:
+      glob: "*.{ts,tsx,js,jsx,py}"
+      run: echo "Format step — configure per language above"
+      priority: 1
+
+    ruff-fix:
+      glob: "*.py"
+      run: ruff check --fix {staged_files} && git add {staged_files}
+      stage_fixed: true
+      priority: 1
+
+    biome-fix:
+      glob: "*.{ts,tsx,js,jsx}"
+      run: biome check --write {staged_files} && git add {staged_files}
+      stage_fixed: true
+      priority: 1
+
+    gitleaks:
+      run: gitleaks protect --staged --no-banner
+      fail_text: "Potential secrets detected"
+      priority: 2
+
+    codespell:
+      glob: "*.{ts,md,txt,yaml,yml,toml,json,py,go,rs}"
+      exclude: "tests/fixtures/.*"
+      run: codespell --check-filenames {staged_files}
+      fail_text: "Spell errors found"
+      priority: 2
+
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}
+      fail_text: "Markdown lint errors found"
+      priority: 2
+
+    no-commits-to-main:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$branch" = "main" ]; then
+          echo "Direct commits to main are not allowed"
+          exit 1
+        fi
+      fail_text: "Do not commit directly to main"
+      priority: 2
+
+commit-msg:
+  commands:
+    conventional:
+      run: grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?:" {1}
+      fail_text: "Commit message must follow Conventional Commits format"
+"
+`;
+
+exports[`generateLefthookConfig output matches snapshot for empty plugins 1`] = `
+"pre-commit:
+  commands:
+
+    gitleaks:
+      run: gitleaks protect --staged --no-banner
+      fail_text: "Potential secrets detected"
+      priority: 2
+
+    codespell:
+      glob: "*.{ts,md,txt,yaml,yml,toml,json,py,go,rs}"
+      exclude: "tests/fixtures/.*"
+      run: codespell --check-filenames {staged_files}
+      fail_text: "Spell errors found"
+      priority: 2
+
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}
+      fail_text: "Markdown lint errors found"
+      priority: 2
+
+    no-commits-to-main:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$branch" = "main" ]; then
+          echo "Direct commits to main are not allowed"
+          exit 1
+        fi
+      fail_text: "Do not commit directly to main"
+      priority: 2
+
+commit-msg:
+  commands:
+    conventional:
+      run: grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?:" {1}
+      fail_text: "Commit message must follow Conventional Commits format"
+"
+`;

--- a/tests/generators/__snapshots__/ruff.test.ts.snap
+++ b/tests/generators/__snapshots__/ruff.test.ts.snap
@@ -1,0 +1,67 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`ruffGenerator output matches snapshot 1`] = `
+"# ai-guardrails:sha256=1ce2b923697e986833cd9f6c09ab23a57b2fca946fc223bd0b27187bb1007007
+target-version = "py311"
+line-length = 88
+indent-width = 4
+fix = false
+unsafe-fixes = false
+
+[lint]
+select = ["ALL"]
+
+ignore = [
+  # --- Formatter conflicts ---
+  "W191", "E111", "E114", "E117", "D206", "D300",
+  "Q000", "Q001", "Q002", "Q003", "COM812", "COM819",
+  "ISC001", "ISC002",
+  # --- Redundant with pyright ---
+  "ANN",
+  # --- Docstrings (opt-in) ---
+  "D",
+  # --- Development markers ---
+  "FIX001", "FIX002", "TD",
+  # --- High false-positive ---
+  "ERA001", "CPY001", "INP001", "T201",
+  "EM101", "EM102", "TRY003", "S101",
+]
+
+[lint.per-file-ignores]
+"tests/**/*.py" = ["ARG001", "ARG002", "PLR2004"]
+"**/__init__.py" = ["F401"]
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.flake8-type-checking]
+strict = true
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
+[lint.isort]
+force-single-line = false
+force-sort-within-sections = true
+combine-as-imports = true
+split-on-trailing-comma = true
+force-to-top = ["__future__"]
+required-imports = ["from __future__ import annotations"]
+
+[lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[lint.mccabe]
+max-complexity = 10
+
+[lint.pylint]
+max-args = 5
+max-branches = 10
+max-locals = 10
+max-statements = 30
+
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "lf"
+"
+`;

--- a/tests/generators/agent-rules.test.ts
+++ b/tests/generators/agent-rules.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AGENT_SYMLINKS,
+  agentRulesGenerator,
+  buildAgentRules,
+  detectAgentTools,
+} from "@/generators/agent-rules";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+const PROJECT_DIR = "/project";
+
+describe("detectAgentTools", () => {
+  test("detects claude from .claude directory", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/.claude/settings.json`, "{}");
+    const result = await detectAgentTools(PROJECT_DIR, fm);
+    expect(result.claude).toBe(true);
+  });
+
+  test("detects cursor from .cursorrules", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/.cursorrules`, "# rules");
+    const result = await detectAgentTools(PROJECT_DIR, fm);
+    expect(result.cursor).toBe(true);
+  });
+
+  test("detects cursor from .cursor/rules directory", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/.cursor/rules/base.md`, "# rules");
+    const result = await detectAgentTools(PROJECT_DIR, fm);
+    expect(result.cursor).toBe(true);
+  });
+
+  test("detects windsurf from .windsurfrules", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/.windsurfrules`, "# rules");
+    const result = await detectAgentTools(PROJECT_DIR, fm);
+    expect(result.windsurf).toBe(true);
+  });
+
+  test("detects copilot from .github/copilot-instructions.md", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/.github/copilot-instructions.md`, "# instructions");
+    const result = await detectAgentTools(PROJECT_DIR, fm);
+    expect(result.copilot).toBe(true);
+  });
+
+  test("detects cline from .clinerules", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/.clinerules`, "# rules");
+    const result = await detectAgentTools(PROJECT_DIR, fm);
+    expect(result.cline).toBe(true);
+  });
+
+  test("detects aider from .aider.conf.yml", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/.aider.conf.yml`, "model: gpt-4");
+    const result = await detectAgentTools(PROJECT_DIR, fm);
+    expect(result.aider).toBe(true);
+  });
+
+  test("returns all false for empty project", async () => {
+    const fm = new FakeFileManager();
+    const result = await detectAgentTools(PROJECT_DIR, fm);
+    expect(result.claude).toBe(false);
+    expect(result.cursor).toBe(false);
+    expect(result.windsurf).toBe(false);
+    expect(result.copilot).toBe(false);
+    expect(result.cline).toBe(false);
+    expect(result.aider).toBe(false);
+  });
+});
+
+describe("buildAgentRules", () => {
+  test("claude rules contain Claude Code Specific section", () => {
+    const rules = buildAgentRules("claude");
+    expect(rules).toContain("Claude Code Specific");
+  });
+
+  test("cursor rules contain Cursor Specific section", () => {
+    const rules = buildAgentRules("cursor");
+    expect(rules).toContain("Cursor Specific");
+  });
+
+  test("all rules contain core principles section", () => {
+    const tools = ["claude", "cursor", "windsurf", "copilot", "cline", "aider"] as const;
+    for (const tool of tools) {
+      const rules = buildAgentRules(tool);
+      expect(rules).toContain("Core Principles");
+    }
+  });
+});
+
+describe("AGENT_SYMLINKS", () => {
+  test("cursor maps to .cursorrules", () => {
+    expect(AGENT_SYMLINKS.cursor).toBe(".cursorrules");
+  });
+
+  test("windsurf maps to .windsurfrules", () => {
+    expect(AGENT_SYMLINKS.windsurf).toBe(".windsurfrules");
+  });
+});
+
+describe("agentRulesGenerator", () => {
+  test("id is agent-rules", () => {
+    expect(agentRulesGenerator.id).toBe("agent-rules");
+  });
+
+  test("output contains base rules", () => {
+    const config = {
+      profile: "standard" as const,
+      ignore: [],
+      allow: [],
+      values: { line_length: 88, indent_width: 4 },
+      ignoredRules: new Set<string>(),
+      isAllowed: () => false,
+    };
+    const output = agentRulesGenerator.generate(config);
+    expect(output).toContain("Core Principles");
+  });
+});

--- a/tests/generators/biome.test.ts
+++ b/tests/generators/biome.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { biomeGenerator } from "@/generators/biome";
+import type { ResolvedConfig } from "@/config/schema";
+
+function makeConfig(overrides?: Partial<ResolvedConfig>): ResolvedConfig {
+  return {
+    profile: "standard",
+    ignore: [],
+    allow: [],
+    values: { line_length: 100, indent_width: 2 },
+    ignoredRules: new Set(),
+    isAllowed: () => false,
+    ...overrides,
+  };
+}
+
+describe("biomeGenerator", () => {
+  test("id is biome", () => {
+    expect(biomeGenerator.id).toBe("biome");
+  });
+
+  test("configFile is biome.json", () => {
+    expect(biomeGenerator.configFile).toBe("biome.json");
+  });
+
+  test("output matches snapshot", () => {
+    const output = biomeGenerator.generate(makeConfig());
+    expect(output).toMatchSnapshot();
+  });
+
+  test("output is valid JSON", () => {
+    const output = biomeGenerator.generate(makeConfig());
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  test("output contains lineWidth from config", () => {
+    const output = biomeGenerator.generate(
+      makeConfig({ values: { line_length: 120, indent_width: 2 } }),
+    );
+    const parsed = JSON.parse(output) as { formatter: { lineWidth: number } };
+    expect(parsed.formatter.lineWidth).toBe(120);
+  });
+
+  test("output has schema reference", () => {
+    const output = biomeGenerator.generate(makeConfig());
+    expect(output).toContain("biomejs.dev/schemas");
+  });
+
+  test("noExplicitAny is error", () => {
+    const output = biomeGenerator.generate(makeConfig());
+    const parsed = JSON.parse(output) as {
+      linter: { rules: { suspicious: { noExplicitAny: string } } };
+    };
+    expect(parsed.linter.rules.suspicious.noExplicitAny).toBe("error");
+  });
+});

--- a/tests/generators/lefthook.test.ts
+++ b/tests/generators/lefthook.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { generateLefthookConfig, lefthookGenerator } from "@/generators/lefthook";
+import type { LanguagePlugin } from "@/languages/types";
+import type { ResolvedConfig } from "@/config/schema";
+
+function makeConfig(overrides?: Partial<ResolvedConfig>): ResolvedConfig {
+  return {
+    profile: "standard",
+    ignore: [],
+    allow: [],
+    values: { line_length: 100, indent_width: 2 },
+    ignoredRules: new Set(),
+    isAllowed: () => false,
+    ...overrides,
+  };
+}
+
+function makePlugin(id: string): LanguagePlugin {
+  return {
+    id,
+    name: id,
+    detect: async () => true,
+    runners: () => [],
+  };
+}
+
+describe("lefthookGenerator", () => {
+  test("id is lefthook", () => {
+    expect(lefthookGenerator.id).toBe("lefthook");
+  });
+
+  test("configFile is lefthook.yml", () => {
+    expect(lefthookGenerator.configFile).toBe("lefthook.yml");
+  });
+
+  test("output contains pre-commit section", () => {
+    const output = lefthookGenerator.generate(makeConfig());
+    expect(output).toContain("pre-commit:");
+  });
+
+  test("output contains commit-msg section", () => {
+    const output = lefthookGenerator.generate(makeConfig());
+    expect(output).toContain("commit-msg:");
+  });
+
+  test("output contains gitleaks", () => {
+    const output = lefthookGenerator.generate(makeConfig());
+    expect(output).toContain("gitleaks");
+  });
+
+  test("output contains codespell", () => {
+    const output = lefthookGenerator.generate(makeConfig());
+    expect(output).toContain("codespell");
+  });
+});
+
+describe("generateLefthookConfig", () => {
+  test("includes python section when python plugin active", () => {
+    const plugins = [makePlugin("python")];
+    const output = generateLefthookConfig(makeConfig(), plugins);
+    expect(output).toContain("ruff");
+  });
+
+  test("includes typescript section when typescript plugin active", () => {
+    const plugins = [makePlugin("typescript")];
+    const output = generateLefthookConfig(makeConfig(), plugins);
+    expect(output).toContain("biome");
+  });
+
+  test("output matches snapshot for python + typescript", () => {
+    const plugins = [makePlugin("python"), makePlugin("typescript")];
+    const output = generateLefthookConfig(makeConfig(), plugins);
+    expect(output).toMatchSnapshot();
+  });
+
+  test("output matches snapshot for empty plugins", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/tests/generators/ruff.test.ts
+++ b/tests/generators/ruff.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { ruffGenerator } from "@/generators/ruff";
+import { verifyHash } from "@/utils/hash";
+import type { ResolvedConfig } from "@/config/schema";
+
+function makeConfig(overrides?: Partial<ResolvedConfig>): ResolvedConfig {
+  return {
+    profile: "standard",
+    ignore: [],
+    allow: [],
+    values: { line_length: 88, indent_width: 4 },
+    ignoredRules: new Set(),
+    isAllowed: () => false,
+    ...overrides,
+  };
+}
+
+describe("ruffGenerator", () => {
+  test("id is ruff", () => {
+    expect(ruffGenerator.id).toBe("ruff");
+  });
+
+  test("configFile is ruff.toml", () => {
+    expect(ruffGenerator.configFile).toBe("ruff.toml");
+  });
+
+  test("output matches snapshot", () => {
+    const output = ruffGenerator.generate(makeConfig());
+    expect(output).toMatchSnapshot();
+  });
+
+  test("output has valid hash header", () => {
+    const output = ruffGenerator.generate(makeConfig());
+    expect(verifyHash(output)).toBe(true);
+  });
+
+  test("output contains line-length from config", () => {
+    const output = ruffGenerator.generate(
+      makeConfig({ values: { line_length: 120, indent_width: 4 } }),
+    );
+    expect(output).toContain("line-length = 120");
+  });
+
+  test("output contains indent-width from config", () => {
+    const output = ruffGenerator.generate(
+      makeConfig({ values: { line_length: 88, indent_width: 2 } }),
+    );
+    expect(output).toContain("indent-width = 2");
+  });
+
+  test("output contains select all", () => {
+    const output = ruffGenerator.generate(makeConfig());
+    expect(output).toContain('select = ["ALL"]');
+  });
+});

--- a/tests/languages/python.test.ts
+++ b/tests/languages/python.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { pythonPlugin } from "@/languages/python";
+import { pyrightRunner } from "@/runners/pyright";
+import { ruffRunner } from "@/runners/ruff";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+const PROJECT_DIR = "/project";
+
+describe("pythonPlugin.detect", () => {
+  test("returns true when pyproject.toml exists", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/pyproject.toml`, "[tool.ruff]");
+    const result = await pythonPlugin.detect({ projectDir: PROJECT_DIR, fileManager: fm });
+    expect(result).toBe(true);
+  });
+
+  test("returns true when .py files exist", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/src/app.py`, "x = 1");
+    const result = await pythonPlugin.detect({ projectDir: PROJECT_DIR, fileManager: fm });
+    expect(result).toBe(true);
+  });
+
+  test("returns false for empty project", async () => {
+    const fm = new FakeFileManager();
+    const result = await pythonPlugin.detect({ projectDir: PROJECT_DIR, fileManager: fm });
+    expect(result).toBe(false);
+  });
+});
+
+describe("pythonPlugin.runners", () => {
+  test("returns ruff and pyright", () => {
+    const runners = pythonPlugin.runners();
+    const ids = runners.map((r) => r.id);
+    expect(ids).toContain(ruffRunner.id);
+    expect(ids).toContain(pyrightRunner.id);
+    expect(runners).toHaveLength(2);
+  });
+});
+
+describe("pythonPlugin metadata", () => {
+  test("id is python", () => {
+    expect(pythonPlugin.id).toBe("python");
+  });
+});

--- a/tests/languages/registry.test.ts
+++ b/tests/languages/registry.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { ALL_PLUGINS, detectLanguages } from "@/languages/registry";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+const PROJECT_DIR = "/project";
+
+describe("ALL_PLUGINS", () => {
+  test("contains 9 plugins", () => {
+    expect(ALL_PLUGINS).toHaveLength(9);
+  });
+
+  test("universal plugin is last", () => {
+    const last = ALL_PLUGINS[ALL_PLUGINS.length - 1];
+    expect(last).toBeDefined();
+    if (!last) return;
+    expect(last.id).toBe("universal");
+  });
+
+  test("all plugin ids are unique", () => {
+    const ids = ALL_PLUGINS.map((p) => p.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+});
+
+describe("detectLanguages", () => {
+  test("always includes universal plugin", async () => {
+    const fm = new FakeFileManager();
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    const ids = active.map((p) => p.id);
+    expect(ids).toContain("universal");
+  });
+
+  test("detects python from pyproject.toml", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/pyproject.toml`, "[tool.ruff]");
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("python");
+  });
+
+  test("detects python from .py files", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/src/main.py`, "print('hello')");
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("python");
+  });
+
+  test("detects typescript from package.json", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/package.json`, '{"name":"foo"}');
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("typescript");
+  });
+
+  test("detects rust from Cargo.toml", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/Cargo.toml`, '[package]\nname = "foo"');
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("rust");
+  });
+
+  test("detects go from go.mod", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/go.mod`, "module example.com/foo");
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("go");
+  });
+
+  test("detects shell from .sh files", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/scripts/build.sh`, "#!/bin/bash");
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("shell");
+  });
+
+  test("detects cpp from CMakeLists.txt", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/CMakeLists.txt`, "cmake_minimum_required(VERSION 3.20)");
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("cpp");
+  });
+
+  test("detects dotnet from .csproj", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/MyApp.csproj`, "<Project />");
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("dotnet");
+  });
+
+  test("detects lua from .lua files", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/src/main.lua`, "print('hello')");
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active.map((p) => p.id)).toContain("lua");
+  });
+
+  test("returns only universal for empty project", async () => {
+    const fm = new FakeFileManager();
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    expect(active).toHaveLength(1);
+    expect(active[0]?.id).toBe("universal");
+  });
+
+  test("returns plugins in priority order", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/pyproject.toml`, "");
+    fm.seed(`${PROJECT_DIR}/Cargo.toml`, "");
+    const active = await detectLanguages(PROJECT_DIR, fm);
+    const ids = active.map((p) => p.id);
+    const pythonIdx = ids.indexOf("python");
+    const rustIdx = ids.indexOf("rust");
+    expect(pythonIdx).toBeLessThan(rustIdx);
+  });
+});

--- a/tests/languages/typescript.test.ts
+++ b/tests/languages/typescript.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { typescriptPlugin } from "@/languages/typescript";
+import { biomeRunner } from "@/runners/biome";
+import { tscRunner } from "@/runners/tsc";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+const PROJECT_DIR = "/project";
+
+describe("typescriptPlugin.detect", () => {
+  test("returns true when package.json exists", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/package.json`, '{"name":"foo"}');
+    const result = await typescriptPlugin.detect({ projectDir: PROJECT_DIR, fileManager: fm });
+    expect(result).toBe(true);
+  });
+
+  test("returns true when .ts files exist", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/src/index.ts`, "export {}");
+    const result = await typescriptPlugin.detect({ projectDir: PROJECT_DIR, fileManager: fm });
+    expect(result).toBe(true);
+  });
+
+  test("returns true when .js files exist", async () => {
+    const fm = new FakeFileManager();
+    fm.seed(`${PROJECT_DIR}/index.js`, 'console.log("hi")');
+    const result = await typescriptPlugin.detect({ projectDir: PROJECT_DIR, fileManager: fm });
+    expect(result).toBe(true);
+  });
+
+  test("returns false for empty project", async () => {
+    const fm = new FakeFileManager();
+    const result = await typescriptPlugin.detect({ projectDir: PROJECT_DIR, fileManager: fm });
+    expect(result).toBe(false);
+  });
+});
+
+describe("typescriptPlugin.runners", () => {
+  test("returns biome and tsc", () => {
+    const runners = typescriptPlugin.runners();
+    const ids = runners.map((r) => r.id);
+    expect(ids).toContain(biomeRunner.id);
+    expect(ids).toContain(tscRunner.id);
+    expect(runners).toHaveLength(2);
+  });
+});
+
+describe("typescriptPlugin metadata", () => {
+  test("id is typescript", () => {
+    expect(typescriptPlugin.id).toBe("typescript");
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 3 from SPEC-007: language detection + config generation.

### Language plugins (`src/languages/`)

- `types.ts` — `LanguagePlugin` interface + `DetectOptions`
- `registry.ts` — `detectLanguages()` with parallel detection, `ALL_PLUGINS` array (9 plugins)
- Per-language plugins: python, typescript, rust, go, shell, cpp, dotnet, lua, universal
- Detection strategy: check marker files first (pyproject.toml, Cargo.toml, go.mod, package.json, CMakeLists.txt), fall back to glob for source files
- Universal plugin always active (codespell + markdownlint)

### Config generators (`src/generators/`)

- `types.ts` — `ConfigGenerator` interface
- `registry.ts` — `ALL_GENERATORS` array
- `ruff.ts` — ruff.toml with battle-tested defaults from SPEC-006, SHA-256 hash header
- `biome.ts` — biome.json from `ResolvedConfig` values (lineWidth, indentWidth)
- `editorconfig.ts` — .editorconfig with hash header
- `markdownlint.ts` — .markdownlint.jsonc
- `codespell.ts` — .codespellrc with hash header
- `lefthook.ts` — language-aware lefthook.yml + `generateLefthookConfig()` for language-specific sections
- `claude-settings.ts` — .claude/settings.json with deny rules
- `agent-rules.ts` — AI tool autodetection (Claude, Cursor, Windsurf, Copilot, Cline, Aider) + per-tool rule generation

### lefthook.yml fix

Updated biome hooks to use `./node_modules/.bin/biome` instead of system `biome` to avoid version conflicts between system biome 2.x and project dev dep 1.9.4.

### Tests (65 new tests across 7 files)

- `languages/registry.test.ts` — detectLanguages, ALL_PLUGINS structure
- `languages/python.test.ts`, `typescript.test.ts` — detect + runners
- `generators/ruff.test.ts` — hash header, config values, snapshot
- `generators/biome.test.ts` — JSON validity, lineWidth, snapshot
- `generators/lefthook.test.ts` — language-aware sections, snapshot
- `generators/agent-rules.test.ts` — detectAgentTools, buildAgentRules, AGENT_SYMLINKS

Full suite: 297 tests, 0 failures. `bun run lint` clean, `bun run typecheck` clean.

## Test plan

- [ ] `bun test` passes (297 tests)
- [ ] `bun run lint` clean
- [ ] `bun run typecheck` clean
- [ ] `detectLanguages` correctly identifies all 9 language types
- [ ] `ruffGenerator` output has valid hash header (`verifyHash` returns true)
- [ ] `generateLefthookConfig` includes Python/TS sections when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)