### PR TITLE
feat(phase-4): pipeline steps and orchestrators with interactive init

### DIFF
--- a/src/models/paths.ts
+++ b/src/models/paths.ts
@@ -1,0 +1,4 @@
+/** Well-known paths used by multiple pipeline steps */
+export const BASELINE_PATH = ".ai-guardrails/baseline.json";
+export const AUDIT_PATH = ".ai-guardrails/audit.jsonl";
+export const PROJECT_CONFIG_PATH = ".ai-guardrails/config.toml";

--- a/src/pipelines/check.ts
+++ b/src/pipelines/check.ts
@@ -1,0 +1,45 @@
+import type { Pipeline, PipelineContext, PipelineResult } from "@/pipelines/types";
+import { detectLanguagesStep } from "@/steps/detect-languages";
+import { loadConfigStep } from "@/steps/load-config";
+import { checkStep } from "@/steps/check-step";
+import { reportStep } from "@/steps/report-step";
+import type { ReportFormat } from "@/steps/report-step";
+
+export const checkPipeline: Pipeline = {
+  async run(ctx: PipelineContext): Promise<PipelineResult> {
+    const { projectDir, fileManager, commandRunner, console: cons } = ctx;
+
+    cons.step("Detecting languages...");
+    const { result: detectResult, languages } = await detectLanguagesStep(projectDir, fileManager);
+    if (detectResult.status === "error") {
+      return { status: "error", message: detectResult.message };
+    }
+    cons.success(detectResult.message);
+
+    cons.step("Loading config...");
+    const { result: configResult, config } = await loadConfigStep(projectDir, fileManager);
+    if (configResult.status === "error" || config === null) {
+      return { status: "error", message: configResult.message };
+    }
+    cons.success(configResult.message);
+
+    cons.step("Running checks...");
+    const { result: checkResult, issues } = await checkStep(
+      projectDir,
+      languages,
+      config,
+      commandRunner,
+      fileManager,
+    );
+
+    const format = (ctx.flags.format as ReportFormat | undefined) ?? "text";
+    await reportStep(issues, format, cons, fileManager);
+
+    if (checkResult.status === "error") {
+      return { status: "error", message: checkResult.message, issueCount: issues.length };
+    }
+
+    cons.success(checkResult.message);
+    return { status: "ok", issueCount: 0 };
+  },
+};

--- a/src/pipelines/generate.ts
+++ b/src/pipelines/generate.ts
@@ -1,0 +1,44 @@
+import type { Pipeline, PipelineContext, PipelineResult } from "@/pipelines/types";
+import { detectLanguagesStep } from "@/steps/detect-languages";
+import { loadConfigStep } from "@/steps/load-config";
+import { generateConfigsStep } from "@/steps/generate-configs";
+import { validateConfigsStep } from "@/steps/validate-configs";
+
+export const generatePipeline: Pipeline = {
+  async run(ctx: PipelineContext): Promise<PipelineResult> {
+    const { projectDir, fileManager, console: cons } = ctx;
+
+    cons.step("Detecting languages...");
+    const { result: detectResult } = await detectLanguagesStep(projectDir, fileManager);
+    if (detectResult.status === "error") {
+      return { status: "error", message: detectResult.message };
+    }
+    cons.success(detectResult.message);
+
+    cons.step("Loading config...");
+    const { result: configResult, config } = await loadConfigStep(projectDir, fileManager);
+    if (configResult.status === "error" || config === null) {
+      return { status: "error", message: configResult.message };
+    }
+    cons.success(configResult.message);
+
+    cons.step("Generating configs...");
+    const genResult = await generateConfigsStep(projectDir, config, fileManager);
+    if (genResult.status === "error") {
+      return { status: "error", message: genResult.message };
+    }
+    cons.success(genResult.message);
+
+    const checkMode = ctx.flags.check === true;
+    if (checkMode) {
+      cons.step("Validating configs...");
+      const validateResult = await validateConfigsStep(projectDir, fileManager);
+      if (validateResult.status === "error") {
+        return { status: "error", message: validateResult.message };
+      }
+      cons.success(validateResult.message);
+    }
+
+    return { status: "ok" };
+  },
+};

--- a/src/pipelines/init.ts
+++ b/src/pipelines/init.ts
@@ -1,0 +1,115 @@
+import type { Console } from "@/infra/console";
+import type { FileManager } from "@/infra/file-manager";
+import { PROJECT_CONFIG_PATH } from "@/models/paths";
+import type { Pipeline, PipelineContext, PipelineResult } from "@/pipelines/types";
+import { installPipeline } from "@/pipelines/install";
+import { dirname, join } from "node:path";
+import { stringify as stringifyToml } from "smol-toml";
+
+type Profile = "strict" | "standard" | "minimal";
+
+const PROFILES: readonly Profile[] = ["strict", "standard", "minimal"] as const;
+
+function isProfile(value: string): value is Profile {
+  return (PROFILES as readonly string[]).includes(value);
+}
+
+async function promptProfile(): Promise<Profile> {
+  process.stdout.write("Select profile [strict/standard/minimal] (default: standard): ");
+  for await (const line of console) {
+    const input = line.trim().toLowerCase();
+    if (input === "" || isProfile(input)) {
+      return (input || "standard") as Profile;
+    }
+    process.stdout.write("Invalid. Choose strict/standard/minimal: ");
+  }
+  return "standard";
+}
+
+async function promptIgnoreRules(): Promise<string[]> {
+  process.stdout.write("Rules to ignore (comma-separated linter/RULE, or press Enter to skip): ");
+  for await (const line of console) {
+    const input = line.trim();
+    if (!input) return [];
+    return input
+      .split(",")
+      .map((r) => r.trim())
+      .filter((r) => r.length > 0);
+  }
+  return [];
+}
+
+async function writeProjectConfig(
+  projectDir: string,
+  profile: Profile,
+  ignoreRules: string[],
+  fileManager: FileManager,
+): Promise<void> {
+  const dest = join(projectDir, PROJECT_CONFIG_PATH);
+  await fileManager.mkdir(dirname(dest), { parents: true });
+
+  const ignoreEntries = ignoreRules.map((rule) => ({
+    rule,
+    reason: "user-configured at init",
+  }));
+
+  const configData: Record<string, unknown> = { profile, ignore: ignoreEntries };
+  await fileManager.writeText(dest, stringifyToml(configData));
+}
+
+async function checkConfigExists(projectDir: string, fileManager: FileManager): Promise<boolean> {
+  try {
+    await fileManager.readText(join(projectDir, PROJECT_CONFIG_PATH));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function logInitStart(cons: Console, interactive: boolean): void {
+  if (interactive) {
+    cons.info("Running interactive init...");
+  } else {
+    cons.info("Running non-interactive init with defaults...");
+  }
+}
+
+export const initPipeline: Pipeline = {
+  async run(ctx: PipelineContext): Promise<PipelineResult> {
+    const { projectDir, fileManager, console: cons } = ctx;
+
+    const force = ctx.flags.force === true;
+    const upgrade = ctx.flags.upgrade === true;
+
+    const configExists = await checkConfigExists(projectDir, fileManager);
+    if (configExists && !force && !upgrade) {
+      return {
+        status: "error",
+        message:
+          ".ai-guardrails/config.toml already exists. Use --force to overwrite or --upgrade to refresh.",
+      };
+    }
+
+    const isInteractive = process.stdin.isTTY === true;
+    logInitStart(cons, isInteractive);
+
+    let profile: Profile = "standard";
+    let ignoreRules: string[] = [];
+
+    if (isInteractive) {
+      profile = await promptProfile();
+      ignoreRules = await promptIgnoreRules();
+    } else {
+      const flagProfile = ctx.flags.profile;
+      if (typeof flagProfile === "string" && isProfile(flagProfile)) {
+        profile = flagProfile;
+      }
+    }
+
+    cons.step(`Writing config: profile=${profile}...`);
+    await writeProjectConfig(projectDir, profile, ignoreRules, fileManager);
+    cons.success("Config written to .ai-guardrails/config.toml");
+
+    return installPipeline.run(ctx);
+  },
+};

--- a/src/pipelines/install.ts
+++ b/src/pipelines/install.ts
@@ -1,0 +1,83 @@
+import type { Pipeline, PipelineContext, PipelineResult } from "@/pipelines/types";
+import { detectLanguagesStep } from "@/steps/detect-languages";
+import { loadConfigStep } from "@/steps/load-config";
+import { generateConfigsStep } from "@/steps/generate-configs";
+import { validateConfigsStep } from "@/steps/validate-configs";
+import { setupHooksStep } from "@/steps/setup-hooks";
+import { setupCiStep } from "@/steps/setup-ci";
+import { setupAgentInstructionsStep } from "@/steps/setup-agent-instructions";
+
+export const installPipeline: Pipeline = {
+  async run(ctx: PipelineContext): Promise<PipelineResult> {
+    const { projectDir, fileManager, commandRunner, console: cons } = ctx;
+
+    cons.step("Detecting languages...");
+    const { result: detectResult, languages } = await detectLanguagesStep(projectDir, fileManager);
+    if (detectResult.status === "error") {
+      return { status: "error", message: detectResult.message };
+    }
+    cons.success(detectResult.message);
+
+    cons.step("Loading config...");
+    const { result: configResult, config } = await loadConfigStep(projectDir, fileManager);
+    if (configResult.status === "error" || config === null) {
+      return { status: "error", message: configResult.message };
+    }
+    cons.success(configResult.message);
+
+    cons.step("Generating configs...");
+    const genResult = await generateConfigsStep(projectDir, config, fileManager);
+    if (genResult.status === "error") {
+      return { status: "error", message: genResult.message };
+    }
+    cons.success(genResult.message);
+
+    cons.step("Validating configs...");
+    const validateResult = await validateConfigsStep(projectDir, fileManager);
+    if (validateResult.status === "error") {
+      return { status: "error", message: validateResult.message };
+    }
+    cons.success(validateResult.message);
+
+    const noHooks = ctx.flags.noHooks === true;
+    if (!noHooks) {
+      cons.step("Installing hooks...");
+      const hooksResult = await setupHooksStep(
+        projectDir,
+        languages,
+        config,
+        fileManager,
+        commandRunner,
+      );
+      if (hooksResult.status === "error") {
+        cons.warning(`Hook setup failed: ${hooksResult.message}`);
+      } else {
+        cons.success(hooksResult.message);
+      }
+    }
+
+    const noCi = ctx.flags.noCi === true;
+    if (!noCi) {
+      cons.step("Setting up CI...");
+      const ciResult = await setupCiStep(projectDir, fileManager);
+      if (ciResult.status === "error") {
+        cons.warning(`CI setup failed: ${ciResult.message}`);
+      } else {
+        cons.success(ciResult.message);
+      }
+    }
+
+    const noAgentRules = ctx.flags.noAgentRules === true;
+    if (!noAgentRules) {
+      cons.step("Setting up agent instructions...");
+      const agentResult = await setupAgentInstructionsStep(projectDir, fileManager);
+      if (agentResult.status === "error") {
+        cons.warning(`Agent instructions failed: ${agentResult.message}`);
+      } else {
+        cons.success(agentResult.message);
+      }
+    }
+
+    return { status: "ok" };
+  },
+};

--- a/src/pipelines/types.ts
+++ b/src/pipelines/types.ts
@@ -1,0 +1,25 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { CommandRunner } from "@/infra/command-runner";
+import type { Console } from "@/infra/console";
+import type { FileManager } from "@/infra/file-manager";
+import type { LanguagePlugin } from "@/languages/types";
+
+export interface PipelineContext {
+  projectDir: string;
+  languages: readonly LanguagePlugin[];
+  config: ResolvedConfig;
+  fileManager: FileManager;
+  commandRunner: CommandRunner;
+  console: Console;
+  flags: Record<string, unknown>;
+}
+
+export interface PipelineResult {
+  status: "ok" | "error";
+  message?: string;
+  issueCount?: number;
+}
+
+export interface Pipeline {
+  run(ctx: PipelineContext): Promise<PipelineResult>;
+}

--- a/src/steps/check-step.ts
+++ b/src/steps/check-step.ts
@@ -1,0 +1,46 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { CommandRunner } from "@/infra/command-runner";
+import type { FileManager } from "@/infra/file-manager";
+import type { LanguagePlugin } from "@/languages/types";
+import type { LintIssue } from "@/models/lint-issue";
+import type { StepResult } from "@/models/step-result";
+import { error, ok } from "@/models/step-result";
+import type { RunOptions } from "@/runners/types";
+
+export interface CheckStepResult {
+  result: StepResult;
+  issues: LintIssue[];
+}
+
+export async function checkStep(
+  projectDir: string,
+  languages: readonly LanguagePlugin[],
+  config: ResolvedConfig,
+  commandRunner: CommandRunner,
+  fileManager: FileManager,
+): Promise<CheckStepResult> {
+  try {
+    const opts: RunOptions = { projectDir, config, commandRunner, fileManager };
+
+    const allIssues = (
+      await Promise.all(
+        languages.flatMap((plugin) => plugin.runners().map((runner) => runner.run(opts))),
+      )
+    ).flat();
+
+    const filtered = allIssues.filter((issue) => !config.isAllowed(issue.rule, issue.file));
+
+    const msg = filtered.length === 0 ? "No new issues found" : `Found ${filtered.length} issue(s)`;
+
+    return {
+      result: filtered.length > 0 ? error(msg) : ok(msg),
+      issues: filtered,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      result: error(`Check failed: ${message}`),
+      issues: [],
+    };
+  }
+}

--- a/src/steps/detect-languages.ts
+++ b/src/steps/detect-languages.ts
@@ -1,0 +1,25 @@
+import type { FileManager } from "@/infra/file-manager";
+import { detectLanguages } from "@/languages/registry";
+import type { LanguagePlugin } from "@/languages/types";
+import { error, ok } from "@/models/step-result";
+import type { StepResult } from "@/models/step-result";
+
+export async function detectLanguagesStep(
+  projectDir: string,
+  fileManager: FileManager,
+): Promise<{ result: StepResult; languages: LanguagePlugin[] }> {
+  try {
+    const languages = await detectLanguages(projectDir, fileManager);
+    const names = languages.map((p) => p.name).join(", ");
+    return {
+      result: ok(`Detected languages: ${names || "none"}`),
+      languages,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      result: error(`Language detection failed: ${message}`),
+      languages: [],
+    };
+  }
+}

--- a/src/steps/generate-configs.ts
+++ b/src/steps/generate-configs.ts
@@ -1,0 +1,47 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { FileManager } from "@/infra/file-manager";
+import { ALL_GENERATORS } from "@/generators/registry";
+import { error, ok } from "@/models/step-result";
+import type { StepResult } from "@/models/step-result";
+import { dirname, join } from "node:path";
+
+async function runGenerator(
+  projectDir: string,
+  config: ResolvedConfig,
+  fileManager: FileManager,
+  generator: (typeof ALL_GENERATORS)[number],
+): Promise<{ file: string } | { error: string }> {
+  try {
+    const content = generator.generate(config);
+    const dest = join(projectDir, generator.configFile);
+    await fileManager.mkdir(dirname(dest), { parents: true });
+    await fileManager.writeText(dest, content);
+    return { file: generator.configFile };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { error: `${generator.id}: ${message}` };
+  }
+}
+
+export async function generateConfigsStep(
+  projectDir: string,
+  config: ResolvedConfig,
+  fileManager: FileManager,
+): Promise<StepResult> {
+  const results = await Promise.all(
+    ALL_GENERATORS.map((g) => runGenerator(projectDir, config, fileManager, g)),
+  );
+
+  const written: string[] = [];
+  const errors: string[] = [];
+  for (const r of results) {
+    if ("file" in r) written.push(r.file);
+    else errors.push(r.error);
+  }
+
+  if (errors.length > 0) {
+    return error(`Config generation failed: ${errors.join(", ")}`);
+  }
+
+  return ok(`Generated ${written.length} config file(s): ${written.join(", ")}`);
+}

--- a/src/steps/load-config.ts
+++ b/src/steps/load-config.ts
@@ -1,0 +1,29 @@
+import { loadMachineConfig, loadProjectConfig, resolveConfig } from "@/config/loader";
+import type { ResolvedConfig } from "@/config/schema";
+import type { FileManager } from "@/infra/file-manager";
+import type { StepResult } from "@/models/step-result";
+import { error, ok } from "@/models/step-result";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export async function loadConfigStep(
+  projectDir: string,
+  fileManager: FileManager,
+): Promise<{ result: StepResult; config: ResolvedConfig | null }> {
+  try {
+    const machinePath = join(homedir(), ".ai-guardrails", "config.toml");
+    const machine = await loadMachineConfig(machinePath, fileManager);
+    const project = await loadProjectConfig(projectDir, fileManager);
+    const config = resolveConfig(machine, project);
+    return {
+      result: ok(`Config loaded: profile=${config.profile}`),
+      config,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      result: error(`Config load failed: ${message}`),
+      config: null,
+    };
+  }
+}

--- a/src/steps/report-step.ts
+++ b/src/steps/report-step.ts
@@ -1,0 +1,31 @@
+import type { Console } from "@/infra/console";
+import type { FileManager } from "@/infra/file-manager";
+import type { LintIssue } from "@/models/lint-issue";
+import { ok } from "@/models/step-result";
+import type { StepResult } from "@/models/step-result";
+import { issuesToSarif } from "@/writers/sarif";
+import { formatIssues } from "@/writers/text";
+
+export type ReportFormat = "text" | "sarif";
+
+export async function reportStep(
+  issues: LintIssue[],
+  format: ReportFormat,
+  console: Console,
+  fileManager: FileManager,
+  sarifOutputPath?: string,
+): Promise<StepResult> {
+  if (format === "sarif") {
+    const sarifJson = JSON.stringify(issuesToSarif(issues), null, 2);
+    if (sarifOutputPath) {
+      await fileManager.writeText(sarifOutputPath, sarifJson);
+    } else {
+      process.stdout.write(`${sarifJson}\n`);
+    }
+  }
+
+  const text = formatIssues(issues);
+  if (text) console.error(text);
+
+  return ok(`Reported ${issues.length} issue(s) in ${format} format`);
+}

--- a/src/steps/setup-agent-instructions.ts
+++ b/src/steps/setup-agent-instructions.ts
@@ -1,0 +1,50 @@
+import type { FileManager } from "@/infra/file-manager";
+import {
+  AGENT_SYMLINKS,
+  buildAgentRules,
+  detectAgentTools,
+  type DetectedAgentTools,
+} from "@/generators/agent-rules";
+import { error, ok } from "@/models/step-result";
+import type { StepResult } from "@/models/step-result";
+import { dirname, join } from "node:path";
+
+async function writeToolRules(
+  projectDir: string,
+  fileManager: FileManager,
+  toolKey: keyof DetectedAgentTools,
+): Promise<string | null> {
+  const symlinkTarget = AGENT_SYMLINKS[toolKey];
+  if (!symlinkTarget) return null;
+
+  const dest = join(projectDir, symlinkTarget);
+  await fileManager.mkdir(dirname(dest), { parents: true });
+  await fileManager.writeText(dest, buildAgentRules(toolKey));
+  return symlinkTarget;
+}
+
+export async function setupAgentInstructionsStep(
+  projectDir: string,
+  fileManager: FileManager,
+): Promise<StepResult> {
+  try {
+    const tools = await detectAgentTools(projectDir, fileManager);
+    const activeKeys = (Object.keys(tools) as Array<keyof DetectedAgentTools>).filter(
+      (key) => tools[key],
+    );
+
+    const results = await Promise.all(
+      activeKeys.map((key) => writeToolRules(projectDir, fileManager, key)),
+    );
+    const written = results.filter((r): r is string => r !== null);
+
+    if (written.length === 0) {
+      return ok("No AI agent tool config detected — skipped agent instructions");
+    }
+
+    return ok(`Agent instructions written: ${written.join(", ")}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return error(`Agent instructions setup failed: ${message}`);
+  }
+}

--- a/src/steps/setup-ci.ts
+++ b/src/steps/setup-ci.ts
@@ -1,0 +1,36 @@
+import type { FileManager } from "@/infra/file-manager";
+import type { StepResult } from "@/models/step-result";
+import { error, ok } from "@/models/step-result";
+import { join } from "node:path";
+
+const CI_WORKFLOW = `name: AI Guardrails Check
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bunx ai-guardrails check
+`;
+
+export async function setupCiStep(
+  projectDir: string,
+  fileManager: FileManager,
+): Promise<StepResult> {
+  try {
+    const workflowDir = join(projectDir, ".github", "workflows");
+    await fileManager.mkdir(workflowDir, { parents: true });
+
+    const dest = join(workflowDir, "ai-guardrails.yml");
+    await fileManager.writeText(dest, CI_WORKFLOW);
+
+    return ok("CI workflow written to .github/workflows/ai-guardrails.yml");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return error(`CI setup failed: ${message}`);
+  }
+}

--- a/src/steps/setup-hooks.ts
+++ b/src/steps/setup-hooks.ts
@@ -1,0 +1,35 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { CommandRunner } from "@/infra/command-runner";
+import type { FileManager } from "@/infra/file-manager";
+import type { LanguagePlugin } from "@/languages/types";
+import type { StepResult } from "@/models/step-result";
+import { error, ok } from "@/models/step-result";
+import { generateLefthookConfig } from "@/generators/lefthook";
+import { join } from "node:path";
+
+export async function setupHooksStep(
+  projectDir: string,
+  languages: readonly LanguagePlugin[],
+  config: ResolvedConfig,
+  fileManager: FileManager,
+  commandRunner: CommandRunner,
+): Promise<StepResult> {
+  try {
+    const content = generateLefthookConfig(config, languages);
+    const dest = join(projectDir, "lefthook.yml");
+    await fileManager.writeText(dest, content);
+
+    const result = await commandRunner.run(["lefthook", "install"], {
+      cwd: projectDir,
+    });
+
+    if (result.exitCode !== 0) {
+      return error(`lefthook install failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+    }
+
+    return ok("Hooks installed via lefthook");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return error(`Hook setup failed: ${message}`);
+  }
+}

--- a/src/steps/snapshot-step.ts
+++ b/src/steps/snapshot-step.ts
@@ -1,0 +1,56 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { CommandRunner } from "@/infra/command-runner";
+import type { FileManager } from "@/infra/file-manager";
+import type { LanguagePlugin } from "@/languages/types";
+import type { BaselineEntry } from "@/models/baseline";
+import type { LintIssue } from "@/models/lint-issue";
+import type { StepResult } from "@/models/step-result";
+import { error, ok } from "@/models/step-result";
+import { BASELINE_PATH } from "@/models/paths";
+import type { RunOptions } from "@/runners/types";
+import { dirname, join } from "node:path";
+
+function issueToEntry(issue: LintIssue): BaselineEntry {
+  return {
+    fingerprint: issue.fingerprint,
+    rule: issue.rule,
+    linter: issue.linter,
+    file: issue.file,
+    line: issue.line,
+    message: issue.message,
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+export async function snapshotStep(
+  projectDir: string,
+  languages: readonly LanguagePlugin[],
+  config: ResolvedConfig,
+  commandRunner: CommandRunner,
+  fileManager: FileManager,
+  baselinePath?: string,
+): Promise<StepResult> {
+  try {
+    const opts: RunOptions = { projectDir, config, commandRunner, fileManager };
+
+    const allIssues = (
+      await Promise.all(
+        languages.flatMap((plugin) => plugin.runners().map((runner) => runner.run(opts))),
+      )
+    ).flat();
+
+    const filtered = allIssues.filter((issue) => !config.isAllowed(issue.rule, issue.file));
+
+    const entries: BaselineEntry[] = filtered.map(issueToEntry);
+    const dest = join(projectDir, baselinePath ?? BASELINE_PATH);
+    await fileManager.mkdir(dirname(dest), { parents: true });
+    await fileManager.writeText(dest, JSON.stringify(entries, null, 2));
+
+    return ok(
+      `Snapshot captured: ${entries.length} issue(s) written to ${baselinePath ?? BASELINE_PATH}`,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return error(`Snapshot failed: ${message}`);
+  }
+}

--- a/src/steps/status-step.ts
+++ b/src/steps/status-step.ts
@@ -1,0 +1,89 @@
+import type { ResolvedConfig } from "@/config/schema";
+import type { CommandRunner } from "@/infra/command-runner";
+import type { Console } from "@/infra/console";
+import type { FileManager } from "@/infra/file-manager";
+import type { LanguagePlugin } from "@/languages/types";
+import { classifyFingerprint, loadBaseline } from "@/models/baseline";
+import type { LintIssue } from "@/models/lint-issue";
+import { BASELINE_PATH } from "@/models/paths";
+import { error, ok } from "@/models/step-result";
+import type { StepResult } from "@/models/step-result";
+import type { RunOptions } from "@/runners/types";
+import { join } from "node:path";
+import { z } from "zod";
+
+const BaselineEntrySchema = z.object({
+  fingerprint: z.string(),
+  rule: z.string(),
+  linter: z.string(),
+  file: z.string(),
+  line: z.number(),
+  message: z.string(),
+  capturedAt: z.string(),
+});
+
+export interface StatusStepOutput {
+  result: StepResult;
+  newIssues: LintIssue[];
+  fixedCount: number;
+  baselineCount: number;
+}
+
+async function loadBaselineFromFile(projectDir: string, fileManager: FileManager) {
+  try {
+    const text = await fileManager.readText(join(projectDir, BASELINE_PATH));
+    const parsed = JSON.parse(text);
+    const entries = z.array(BaselineEntrySchema).parse(parsed);
+    return loadBaseline(entries);
+  } catch {
+    return null;
+  }
+}
+
+export async function statusStep(
+  projectDir: string,
+  languages: readonly LanguagePlugin[],
+  config: ResolvedConfig,
+  commandRunner: CommandRunner,
+  fileManager: FileManager,
+  console: Console,
+): Promise<StatusStepOutput> {
+  try {
+    const baseline = await loadBaselineFromFile(projectDir, fileManager);
+    const baselineMap = baseline ?? new Map();
+
+    const opts: RunOptions = { projectDir, config, commandRunner, fileManager };
+    const allIssues = (
+      await Promise.all(
+        languages.flatMap((plugin) => plugin.runners().map((runner) => runner.run(opts))),
+      )
+    ).flat();
+
+    const filtered = allIssues.filter((issue) => !config.isAllowed(issue.rule, issue.file));
+
+    const newIssues = filtered.filter(
+      (issue) => classifyFingerprint(issue.fingerprint, baselineMap) === "new",
+    );
+
+    const fixedCount = Math.max(0, baselineMap.size - filtered.length);
+    const baselineCount = baselineMap.size;
+
+    const msg = `Status: ${newIssues.length} new, ${fixedCount} fixed, ${baselineCount} baseline`;
+    console.info(msg);
+
+    return {
+      result: ok(msg),
+      newIssues,
+      fixedCount,
+      baselineCount,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      result: error(`Status check failed: ${message}`),
+      newIssues: [],
+      fixedCount: 0,
+      baselineCount: 0,
+    };
+  }
+}

--- a/src/steps/validate-configs.ts
+++ b/src/steps/validate-configs.ts
@@ -1,0 +1,38 @@
+import type { FileManager } from "@/infra/file-manager";
+import { ALL_GENERATORS } from "@/generators/registry";
+import { error, ok } from "@/models/step-result";
+import type { StepResult } from "@/models/step-result";
+import { join } from "node:path";
+
+async function validateOne(
+  dest: string,
+  configFile: string,
+  fileManager: FileManager,
+): Promise<string | null> {
+  try {
+    const content = await fileManager.readText(dest);
+    if (!content.trim()) return `empty: ${configFile}`;
+    return null;
+  } catch {
+    return `missing: ${configFile}`;
+  }
+}
+
+export async function validateConfigsStep(
+  projectDir: string,
+  fileManager: FileManager,
+): Promise<StepResult> {
+  const problems = (
+    await Promise.all(
+      ALL_GENERATORS.map((g) =>
+        validateOne(join(projectDir, g.configFile), g.configFile, fileManager),
+      ),
+    )
+  ).filter((p): p is string => p !== null);
+
+  if (problems.length > 0) {
+    return error(`Config validation failed: ${problems.join(", ")}`);
+  }
+
+  return ok(`All ${ALL_GENERATORS.length} config files validated`);
+}

--- a/src/templates/workflows/ai-guardrails.yml
+++ b/src/templates/workflows/ai-guardrails.yml
@@ -1,0 +1,12 @@
+name: AI Guardrails Check
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bunx ai-guardrails check

--- a/src/writers/sarif.ts
+++ b/src/writers/sarif.ts
@@ -1,0 +1,67 @@
+import type { LintIssue } from "@/models/lint-issue";
+
+interface SarifLocation {
+  physicalLocation: {
+    artifactLocation: { uri: string };
+    region: { startLine: number; startColumn: number };
+  };
+}
+
+interface SarifResult {
+  ruleId: string;
+  level: "error" | "warning" | "note";
+  message: { text: string };
+  locations: SarifLocation[];
+}
+
+interface SarifRun {
+  tool: { driver: { name: string; version: string; rules: unknown[] } };
+  results: SarifResult[];
+}
+
+interface SarifLog {
+  version: "2.1.0";
+  $schema: string;
+  runs: SarifRun[];
+}
+
+function severityToLevel(severity: LintIssue["severity"]): SarifResult["level"] {
+  return severity === "error" ? "error" : "warning";
+}
+
+/**
+ * Convert LintIssue[] to SARIF 2.1.0 format.
+ */
+export function issuesToSarif(issues: LintIssue[]): SarifLog {
+  const results: SarifResult[] = issues.map((issue) => ({
+    ruleId: `${issue.linter}/${issue.rule}`,
+    level: severityToLevel(issue.severity),
+    message: { text: issue.message },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: { uri: issue.file },
+          region: { startLine: issue.line, startColumn: issue.col },
+        },
+      },
+    ],
+  }));
+
+  const run: SarifRun = {
+    tool: {
+      driver: {
+        name: "ai-guardrails",
+        version: "3.0.0",
+        rules: [],
+      },
+    },
+    results,
+  };
+
+  return {
+    version: "2.1.0",
+    $schema:
+      "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    runs: [run],
+  };
+}

--- a/src/writers/text.ts
+++ b/src/writers/text.ts
@@ -1,0 +1,28 @@
+import type { LintIssue } from "@/models/lint-issue";
+
+/**
+ * Format a list of lint issues as human-readable text.
+ * Returns an empty string if there are no issues.
+ */
+export function formatIssues(issues: LintIssue[]): string {
+  if (issues.length === 0) return "";
+
+  const lines: string[] = [];
+  for (const issue of issues) {
+    const location = `${issue.file}:${issue.line}:${issue.col}`;
+    const severity = issue.severity.toUpperCase();
+    lines.push(`${location}: [${severity}] ${issue.linter}/${issue.rule}: ${issue.message}`);
+  }
+  lines.push("");
+  lines.push(`${issues.length} issue(s) found`);
+  return lines.join("\n");
+}
+
+/**
+ * Format a single lint issue as a string.
+ */
+export function formatIssue(issue: LintIssue): string {
+  const location = `${issue.file}:${issue.line}:${issue.col}`;
+  const severity = issue.severity.toUpperCase();
+  return `${location}: [${severity}] ${issue.linter}/${issue.rule}: ${issue.message}`;
+}

--- a/tests/pipelines/check.test.ts
+++ b/tests/pipelines/check.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { checkPipeline } from "@/pipelines/check";
+import type { PipelineContext } from "@/pipelines/types";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+import { FakeConsole } from "../fakes/fake-console";
+import { buildResolvedConfig, MachineConfigSchema, ProjectConfigSchema } from "@/config/schema";
+
+function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  const machine = MachineConfigSchema.parse({});
+  const project = ProjectConfigSchema.parse({});
+  const config = buildResolvedConfig(machine, project);
+  const fm = new FakeFileManager();
+  // Python project — needed for language detection
+  fm.seed("/project/pyproject.toml", "[tool.ruff]");
+
+  return {
+    projectDir: "/project",
+    languages: [],
+    config,
+    fileManager: fm,
+    commandRunner: new FakeCommandRunner(),
+    console: new FakeConsole(),
+    flags: {},
+    ...overrides,
+  };
+}
+
+describe("checkPipeline", () => {
+  test("returns ok when runners produce no issues", async () => {
+    const ctx = makeCtx();
+    // Ruff returns no issues (empty array JSON)
+    (ctx.commandRunner as FakeCommandRunner).register(
+      ["ruff", "check", "--output-format=json", "/project"],
+      { stdout: "[]", stderr: "", exitCode: 0 },
+    );
+
+    const result = await checkPipeline.run(ctx);
+
+    expect(result.status).toBe("ok");
+  });
+
+  test("returns error when runners produce issues", async () => {
+    const ctx = makeCtx();
+    const ruffOutput = JSON.stringify([
+      {
+        code: "E501",
+        filename: "/project/foo.py",
+        location: { row: 1, column: 1 },
+        message: "Line too long",
+      },
+    ]);
+    (ctx.commandRunner as FakeCommandRunner).register(
+      ["ruff", "check", "--output-format=json", "/project"],
+      { stdout: ruffOutput, stderr: "", exitCode: 1 },
+    );
+
+    const result = await checkPipeline.run(ctx);
+
+    expect(result.status).toBe("error");
+    expect(result.issueCount).toBeGreaterThan(0);
+  });
+
+  test("reports steps to console", async () => {
+    const ctx = makeCtx();
+    const cons = ctx.console as FakeConsole;
+
+    await checkPipeline.run(ctx);
+
+    expect(cons.steps.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/pipelines/install.test.ts
+++ b/tests/pipelines/install.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { installPipeline } from "@/pipelines/install";
+import type { PipelineContext } from "@/pipelines/types";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+import { FakeConsole } from "../fakes/fake-console";
+import { buildResolvedConfig, MachineConfigSchema, ProjectConfigSchema } from "@/config/schema";
+import { ALL_GENERATORS } from "@/generators/registry";
+
+function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  const machine = MachineConfigSchema.parse({});
+  const project = ProjectConfigSchema.parse({});
+  const config = buildResolvedConfig(machine, project);
+  const fm = new FakeFileManager();
+  fm.seed("/project/pyproject.toml", "[tool.ruff]");
+
+  return {
+    projectDir: "/project",
+    languages: [],
+    config,
+    fileManager: fm,
+    commandRunner: new FakeCommandRunner(),
+    console: new FakeConsole(),
+    flags: {},
+    ...overrides,
+  };
+}
+
+describe("installPipeline", () => {
+  test("returns ok and writes all config files", async () => {
+    const ctx = makeCtx();
+
+    const result = await installPipeline.run(ctx);
+
+    expect(result.status).toBe("ok");
+    const writtenPaths = (ctx.fileManager as FakeFileManager).written.map(([p]) => p);
+    // At minimum all generators should have written files
+    expect(writtenPaths.length).toBeGreaterThanOrEqual(ALL_GENERATORS.length);
+  });
+
+  test("writes lefthook.yml", async () => {
+    const ctx = makeCtx();
+
+    await installPipeline.run(ctx);
+
+    const writtenPaths = (ctx.fileManager as FakeFileManager).written.map(([p]) => p);
+    const hasLefthook = writtenPaths.some((p) => p.endsWith("lefthook.yml"));
+    expect(hasLefthook).toBe(true);
+  });
+
+  test("runs lefthook install", async () => {
+    const ctx = makeCtx();
+    const cr = ctx.commandRunner as FakeCommandRunner;
+
+    await installPipeline.run(ctx);
+
+    const hasLefthookInstall = cr.calls.some(
+      (args) => args[0] === "lefthook" && args[1] === "install",
+    );
+    expect(hasLefthookInstall).toBe(true);
+  });
+
+  test("writes CI workflow file", async () => {
+    const ctx = makeCtx();
+
+    await installPipeline.run(ctx);
+
+    const writtenPaths = (ctx.fileManager as FakeFileManager).written.map(([p]) => p);
+    const hasCi = writtenPaths.some((p) => p.includes("ai-guardrails.yml"));
+    expect(hasCi).toBe(true);
+  });
+
+  test("skips hooks when noHooks flag is set", async () => {
+    const ctx = makeCtx({ flags: { noHooks: true } });
+    const cr = ctx.commandRunner as FakeCommandRunner;
+
+    await installPipeline.run(ctx);
+
+    const hasLefthookInstall = cr.calls.some(
+      (args) => args[0] === "lefthook" && args[1] === "install",
+    );
+    expect(hasLefthookInstall).toBe(false);
+  });
+
+  test("skips CI when noCi flag is set", async () => {
+    const ctx = makeCtx({ flags: { noCi: true } });
+
+    await installPipeline.run(ctx);
+
+    const writtenPaths = (ctx.fileManager as FakeFileManager).written.map(([p]) => p);
+    const hasCi = writtenPaths.some((p) => p.includes("ai-guardrails.yml"));
+    expect(hasCi).toBe(false);
+  });
+
+  test("reports progress steps to console", async () => {
+    const ctx = makeCtx();
+    const cons = ctx.console as FakeConsole;
+
+    await installPipeline.run(ctx);
+
+    expect(cons.steps.length).toBeGreaterThan(0);
+    expect(cons.successes.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/steps/check-step.test.ts
+++ b/tests/steps/check-step.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { checkStep } from "@/steps/check-step";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+import { buildResolvedConfig, MachineConfigSchema, ProjectConfigSchema } from "@/config/schema";
+import type { LanguagePlugin } from "@/languages/types";
+import type { LinterRunner, RunOptions } from "@/runners/types";
+import type { LintIssue } from "@/models/lint-issue";
+
+function makeConfig() {
+  const machine = MachineConfigSchema.parse({});
+  const project = ProjectConfigSchema.parse({});
+  return buildResolvedConfig(machine, project);
+}
+
+function makeIssue(overrides: Partial<LintIssue> = {}): LintIssue {
+  return {
+    rule: "ruff/E501",
+    linter: "ruff",
+    file: "/project/foo.py",
+    line: 1,
+    col: 1,
+    message: "Line too long",
+    severity: "error",
+    fingerprint: "abc123",
+    ...overrides,
+  };
+}
+
+function makeRunner(issues: LintIssue[]): LinterRunner {
+  return {
+    id: "test-runner",
+    name: "Test Runner",
+    configFile: null,
+    async isAvailable() {
+      return true;
+    },
+    async run(_opts: RunOptions): Promise<LintIssue[]> {
+      return issues;
+    },
+    generateConfig() {
+      return null;
+    },
+  };
+}
+
+function makePlugin(issues: LintIssue[]): LanguagePlugin {
+  return {
+    id: "test",
+    name: "Test",
+    async detect() {
+      return true;
+    },
+    runners() {
+      return [makeRunner(issues)];
+    },
+  };
+}
+
+describe("checkStep", () => {
+  test("returns ok when no issues found", async () => {
+    const fm = new FakeFileManager();
+    const cr = new FakeCommandRunner();
+    const config = makeConfig();
+    const languages = [makePlugin([])];
+
+    const { result, issues } = await checkStep("/project", languages, config, cr, fm);
+
+    expect(result.status).toBe("ok");
+    expect(issues).toHaveLength(0);
+  });
+
+  test("returns error when issues found", async () => {
+    const fm = new FakeFileManager();
+    const cr = new FakeCommandRunner();
+    const config = makeConfig();
+    const languages = [makePlugin([makeIssue()])];
+
+    const { result, issues } = await checkStep("/project", languages, config, cr, fm);
+
+    expect(result.status).toBe("error");
+    expect(issues).toHaveLength(1);
+  });
+
+  test("filters allowed rules from results", async () => {
+    const fm = new FakeFileManager();
+    const cr = new FakeCommandRunner();
+    const machine = MachineConfigSchema.parse({
+      ignore: [{ rule: "ruff/E501", reason: "allowed" }],
+    });
+    const project = ProjectConfigSchema.parse({});
+    const config = buildResolvedConfig(machine, project);
+
+    const languages = [makePlugin([makeIssue({ rule: "ruff/E501" })])];
+
+    const { result, issues } = await checkStep("/project", languages, config, cr, fm);
+
+    expect(result.status).toBe("ok");
+    expect(issues).toHaveLength(0);
+  });
+
+  test("aggregates issues from multiple runners", async () => {
+    const fm = new FakeFileManager();
+    const cr = new FakeCommandRunner();
+    const config = makeConfig();
+
+    const plugin1 = makePlugin([makeIssue({ rule: "ruff/E501" })]);
+    const plugin2 = makePlugin([makeIssue({ rule: "ruff/F401" })]);
+
+    const { issues } = await checkStep("/project", [plugin1, plugin2], config, cr, fm);
+
+    expect(issues).toHaveLength(2);
+  });
+});

--- a/tests/steps/detect-languages.test.ts
+++ b/tests/steps/detect-languages.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { detectLanguagesStep } from "@/steps/detect-languages";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+
+describe("detectLanguagesStep", () => {
+  test("returns ok with detected languages for a python project", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("/project/pyproject.toml", "[tool.ruff]");
+
+    const { result, languages } = await detectLanguagesStep("/project", fm);
+
+    expect(result.status).toBe("ok");
+    expect(languages.map((l) => l.id)).toContain("python");
+    expect(languages.map((l) => l.id)).toContain("universal");
+  });
+
+  test("always includes universal plugin", async () => {
+    const fm = new FakeFileManager();
+    // No project files seeded
+
+    const { result, languages } = await detectLanguagesStep("/empty", fm);
+
+    expect(result.status).toBe("ok");
+    expect(languages.map((l) => l.id)).toContain("universal");
+  });
+
+  test("detects multiple languages", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("/project/pyproject.toml", "[tool.ruff]");
+    fm.seed("/project/Cargo.toml", "[package]");
+
+    const { result, languages } = await detectLanguagesStep("/project", fm);
+
+    expect(result.status).toBe("ok");
+    const ids = languages.map((l) => l.id);
+    expect(ids).toContain("python");
+    expect(ids).toContain("rust");
+  });
+
+  test("returns ok message listing language names", async () => {
+    const fm = new FakeFileManager();
+    fm.seed("/project/package.json", "{}");
+
+    const { result } = await detectLanguagesStep("/project", fm);
+
+    expect(result.status).toBe("ok");
+    expect(result.message).toContain("Detected");
+  });
+});

--- a/tests/steps/generate-configs.test.ts
+++ b/tests/steps/generate-configs.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { generateConfigsStep } from "@/steps/generate-configs";
+import { ALL_GENERATORS } from "@/generators/registry";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+import { buildResolvedConfig } from "@/config/schema";
+import { MachineConfigSchema, ProjectConfigSchema } from "@/config/schema";
+
+function makeConfig() {
+  const machine = MachineConfigSchema.parse({});
+  const project = ProjectConfigSchema.parse({});
+  return buildResolvedConfig(machine, project);
+}
+
+describe("generateConfigsStep", () => {
+  test("writes all generator outputs to projectDir", async () => {
+    const fm = new FakeFileManager();
+    const config = makeConfig();
+
+    const result = await generateConfigsStep("/project", config, fm);
+
+    expect(result.status).toBe("ok");
+    expect(fm.written.length).toBe(ALL_GENERATORS.length);
+  });
+
+  test("each written file path is under the projectDir", async () => {
+    const fm = new FakeFileManager();
+    const config = makeConfig();
+
+    await generateConfigsStep("/project", config, fm);
+
+    for (const [path] of fm.written) {
+      expect(path.startsWith("/project/")).toBe(true);
+    }
+  });
+
+  test("written files have non-empty content", async () => {
+    const fm = new FakeFileManager();
+    const config = makeConfig();
+
+    await generateConfigsStep("/project", config, fm);
+
+    for (const [, content] of fm.written) {
+      expect(content.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("result message lists generated files", async () => {
+    const fm = new FakeFileManager();
+    const config = makeConfig();
+
+    const result = await generateConfigsStep("/project", config, fm);
+
+    expect(result.message).toContain("Generated");
+    expect(result.message).toContain(String(ALL_GENERATORS.length));
+  });
+});

--- a/tests/steps/status-step.test.ts
+++ b/tests/steps/status-step.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { statusStep } from "@/steps/status-step";
+import { FakeFileManager } from "../fakes/fake-file-manager";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+import { FakeConsole } from "../fakes/fake-console";
+import { buildResolvedConfig, MachineConfigSchema, ProjectConfigSchema } from "@/config/schema";
+import type { LanguagePlugin } from "@/languages/types";
+import type { LinterRunner, RunOptions } from "@/runners/types";
+import type { LintIssue } from "@/models/lint-issue";
+import type { BaselineEntry } from "@/models/baseline";
+
+function makeConfig() {
+  const machine = MachineConfigSchema.parse({});
+  const project = ProjectConfigSchema.parse({});
+  return buildResolvedConfig(machine, project);
+}
+
+function makeIssue(overrides: Partial<LintIssue> = {}): LintIssue {
+  return {
+    rule: "ruff/E501",
+    linter: "ruff",
+    file: "/project/foo.py",
+    line: 1,
+    col: 1,
+    message: "Line too long",
+    severity: "error",
+    fingerprint: "fp-001",
+    ...overrides,
+  };
+}
+
+function makeRunner(issues: LintIssue[]): LinterRunner {
+  return {
+    id: "test-runner",
+    name: "Test Runner",
+    configFile: null,
+    async isAvailable() {
+      return true;
+    },
+    async run(_opts: RunOptions): Promise<LintIssue[]> {
+      return issues;
+    },
+    generateConfig() {
+      return null;
+    },
+  };
+}
+
+function makePlugin(issues: LintIssue[]): LanguagePlugin {
+  return {
+    id: "test",
+    name: "Test",
+    async detect() {
+      return true;
+    },
+    runners() {
+      return [makeRunner(issues)];
+    },
+  };
+}
+
+function makeBaselineEntry(fingerprint: string): BaselineEntry {
+  return {
+    fingerprint,
+    rule: "ruff/E501",
+    linter: "ruff",
+    file: "/project/foo.py",
+    line: 1,
+    message: "Line too long",
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+describe("statusStep", () => {
+  test("returns ok when no issues and no baseline", async () => {
+    const fm = new FakeFileManager();
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const config = makeConfig();
+
+    const output = await statusStep("/project", [makePlugin([])], config, cr, fm, cons);
+
+    expect(output.result.status).toBe("ok");
+    expect(output.newIssues).toHaveLength(0);
+    expect(output.fixedCount).toBe(0);
+  });
+
+  test("identifies new issues not in baseline", async () => {
+    const fm = new FakeFileManager();
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const config = makeConfig();
+
+    const baselineEntries = [makeBaselineEntry("fp-baseline")];
+    fm.seed("/project/.ai-guardrails/baseline.json", JSON.stringify(baselineEntries));
+
+    const newIssue = makeIssue({ fingerprint: "fp-new" });
+    const output = await statusStep("/project", [makePlugin([newIssue])], config, cr, fm, cons);
+
+    expect(output.result.status).toBe("ok");
+    expect(output.newIssues).toHaveLength(1);
+    expect(output.baselineCount).toBe(1);
+  });
+
+  test("counts fixed issues when baseline has more than current", async () => {
+    const fm = new FakeFileManager();
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const config = makeConfig();
+
+    const baselineEntries = [makeBaselineEntry("fp-001"), makeBaselineEntry("fp-002")];
+    fm.seed("/project/.ai-guardrails/baseline.json", JSON.stringify(baselineEntries));
+
+    // Current scan finds no issues
+    const output = await statusStep("/project", [makePlugin([])], config, cr, fm, cons);
+
+    expect(output.fixedCount).toBe(2);
+    expect(output.baselineCount).toBe(2);
+  });
+
+  test("logs status message to console", async () => {
+    const fm = new FakeFileManager();
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const config = makeConfig();
+
+    await statusStep("/project", [makePlugin([])], config, cr, fm, cons);
+
+    expect(cons.infos.length).toBeGreaterThan(0);
+    expect(cons.infos[0]).toContain("Status:");
+  });
+});

--- a/tests/writers/sarif.test.ts
+++ b/tests/writers/sarif.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { issuesToSarif } from "@/writers/sarif";
+import type { LintIssue } from "@/models/lint-issue";
+
+function makeIssue(overrides: Partial<LintIssue> = {}): LintIssue {
+  return {
+    rule: "E501",
+    linter: "ruff",
+    file: "/project/foo.py",
+    line: 10,
+    col: 1,
+    message: "Line too long",
+    severity: "error",
+    fingerprint: "abc123",
+    ...overrides,
+  };
+}
+
+describe("issuesToSarif", () => {
+  test("produces SARIF 2.1.0 version", () => {
+    const sarif = issuesToSarif([]);
+    expect(sarif.version).toBe("2.1.0");
+  });
+
+  test("includes $schema field", () => {
+    const sarif = issuesToSarif([]);
+    expect(sarif.$schema).toContain("sarif-schema-2.1.0");
+  });
+
+  test("includes one run", () => {
+    const sarif = issuesToSarif([]);
+    expect(sarif.runs).toHaveLength(1);
+  });
+
+  test("tool name is ai-guardrails", () => {
+    const sarif = issuesToSarif([]);
+    expect(sarif.runs[0]?.tool.driver.name).toBe("ai-guardrails");
+  });
+
+  test("produces empty results for no issues", () => {
+    const sarif = issuesToSarif([]);
+    expect(sarif.runs[0]?.results).toHaveLength(0);
+  });
+
+  test("maps issue to SARIF result with correct ruleId", () => {
+    const issue = makeIssue({ linter: "ruff", rule: "E501" });
+    const sarif = issuesToSarif([issue]);
+    const result = sarif.runs[0]?.results[0];
+    expect(result?.ruleId).toBe("ruff/E501");
+  });
+
+  test("maps severity error to SARIF level error", () => {
+    const issue = makeIssue({ severity: "error" });
+    const sarif = issuesToSarif([issue]);
+    expect(sarif.runs[0]?.results[0]?.level).toBe("error");
+  });
+
+  test("maps severity warning to SARIF level warning", () => {
+    const issue = makeIssue({ severity: "warning" });
+    const sarif = issuesToSarif([issue]);
+    expect(sarif.runs[0]?.results[0]?.level).toBe("warning");
+  });
+
+  test("includes file URI and line/col in location", () => {
+    const issue = makeIssue({ file: "/project/foo.py", line: 42, col: 7 });
+    const sarif = issuesToSarif([issue]);
+    const location = sarif.runs[0]?.results[0]?.locations[0];
+    expect(location?.physicalLocation.artifactLocation.uri).toBe("/project/foo.py");
+    expect(location?.physicalLocation.region.startLine).toBe(42);
+    expect(location?.physicalLocation.region.startColumn).toBe(7);
+  });
+
+  test("includes message text", () => {
+    const issue = makeIssue({ message: "Line too long (120 > 88)" });
+    const sarif = issuesToSarif([issue]);
+    expect(sarif.runs[0]?.results[0]?.message.text).toBe("Line too long (120 > 88)");
+  });
+
+  test("handles multiple issues", () => {
+    const issues = [makeIssue(), makeIssue({ rule: "F401", message: "Unused import" })];
+    const sarif = issuesToSarif(issues);
+    expect(sarif.runs[0]?.results).toHaveLength(2);
+  });
+});

--- a/tests/writers/text.test.ts
+++ b/tests/writers/text.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { formatIssues, formatIssue } from "@/writers/text";
+import type { LintIssue } from "@/models/lint-issue";
+
+function makeIssue(overrides: Partial<LintIssue> = {}): LintIssue {
+  return {
+    rule: "E501",
+    linter: "ruff",
+    file: "/project/foo.py",
+    line: 10,
+    col: 1,
+    message: "Line too long",
+    severity: "error",
+    fingerprint: "abc123",
+    ...overrides,
+  };
+}
+
+describe("formatIssues", () => {
+  test("returns empty string for no issues", () => {
+    expect(formatIssues([])).toBe("");
+  });
+
+  test("includes file, line, col in output", () => {
+    const issue = makeIssue({ file: "/project/foo.py", line: 42, col: 5 });
+    const output = formatIssues([issue]);
+    expect(output).toContain("/project/foo.py:42:5");
+  });
+
+  test("includes linter and rule in output", () => {
+    const issue = makeIssue({ linter: "ruff", rule: "E501" });
+    const output = formatIssues([issue]);
+    expect(output).toContain("ruff/E501");
+  });
+
+  test("includes message in output", () => {
+    const issue = makeIssue({ message: "Line too long (120 > 88)" });
+    const output = formatIssues([issue]);
+    expect(output).toContain("Line too long (120 > 88)");
+  });
+
+  test("includes severity in output", () => {
+    const issue = makeIssue({ severity: "warning" });
+    const output = formatIssues([issue]);
+    expect(output).toContain("WARNING");
+  });
+
+  test("shows issue count summary", () => {
+    const issues = [makeIssue(), makeIssue({ rule: "F401" })];
+    const output = formatIssues(issues);
+    expect(output).toContain("2 issue(s)");
+  });
+
+  test("formats multiple issues as separate lines", () => {
+    const issues = [makeIssue({ file: "/a.py", line: 1 }), makeIssue({ file: "/b.py", line: 2 })];
+    const output = formatIssues(issues);
+    expect(output).toContain("/a.py");
+    expect(output).toContain("/b.py");
+  });
+});
+
+describe("formatIssue", () => {
+  test("formats a single issue", () => {
+    const issue = makeIssue({ file: "/foo.py", line: 5, col: 3, rule: "E501", linter: "ruff" });
+    const output = formatIssue(issue);
+    expect(output).toContain("/foo.py:5:3");
+    expect(output).toContain("ruff/E501");
+  });
+});


### PR DESCRIPTION
## Summary

- Implements all 11 pipeline steps (`detect-languages`, `load-config`, `generate-configs`, `validate-configs`, `check-step`, `snapshot-step`, `status-step`, `report-step`, `setup-hooks`, `setup-ci`, `setup-agent-instructions`)
- Implements 4 pipeline orchestrators (`install`, `init` with TTY-aware interactive prompts, `check`, `generate`)
- SARIF 2.1.0 writer (`src/writers/sarif.ts`) and human-readable text writer (`src/writers/text.ts`)
- Shared well-known paths constant in `src/models/paths.ts` (`BASELINE_PATH`, `AUDIT_PATH`, `PROJECT_CONFIG_PATH`)
- CI workflow template at `src/templates/workflows/ai-guardrails.yml`
- 45 new tests across steps, pipelines, and writers (342 total passing)

## Design decisions

- `init` pipeline detects `process.stdin.isTTY` — prompts for profile and ignore rules interactively on TTY, silently uses defaults in CI/pipe
- Generators and validators run in parallel via `Promise.all` — no sequential bottleneck
- TOCTOU `exists()` + `readText()` patterns eliminated — operate directly and handle errors
- Duplicated `BASELINE_PATH` constant extracted to `src/models/paths.ts`
- `setup-agent-instructions` writes files in parallel per detected AI tool

## Test plan

- [ ] `bun test` — 342 pass, 0 fail
- [ ] `bun run lint` — no errors
- [ ] `bun run typecheck` — no errors
- [ ] `tests/steps/` covers detect-languages, check-step, generate-configs, status-step
- [ ] `tests/pipelines/` covers check and install end-to-end with fakes
- [ ] `tests/writers/` covers text and SARIF formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)