### PR TITLE
fix(hooks): eliminate double type assertions and log silent catch in format-stage

### DIFF
--- a/src/hooks/dangerous-cmd.ts
+++ b/src/hooks/dangerous-cmd.ts
@@ -1,5 +1,5 @@
-import type { BashToolInput } from "@/hooks/types";
 import { allow, deny, readHookInput } from "@/hooks/runner";
+import { extractBashCommand } from "@/hooks/types";
 
 const BLOCKED_PATTERNS: RegExp[] = [
   /rm\s+-rf?\s+[^/\s]*\/?\s*$|rm\s+-rf\s+\//,
@@ -21,8 +21,8 @@ export function isDangerous(command: string): string | null {
 
 export async function runDangerousCmd(): Promise<never> {
   const input = await readHookInput();
-  const bash = input.tool_input as unknown as BashToolInput;
-  const reason = isDangerous(bash.command ?? "");
+  const command = extractBashCommand(input.tool_input);
+  const reason = isDangerous(command);
   if (reason !== null) {
     deny(reason);
   }

--- a/src/hooks/format-stage.ts
+++ b/src/hooks/format-stage.ts
@@ -18,8 +18,11 @@ function tryRun(args: string[]): void {
   if (!cmd) return;
   try {
     spawnSync(cmd, rest, { stdio: "inherit" });
-  } catch {
-    // formatter not installed or failed — lefthook will report
+  } catch (err) {
+    // Formatter not installed or failed to spawn — lefthook will report exit status.
+    // Log the raw error so the cause is visible in hook output.
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[format-stage] failed to run ${cmd}: ${message}\n`);
   }
 }
 

--- a/src/hooks/protect-configs.ts
+++ b/src/hooks/protect-configs.ts
@@ -1,5 +1,5 @@
-import type { BashToolInput } from "@/hooks/types";
 import { allow, deny, readHookInput } from "@/hooks/runner";
+import { extractBashCommand } from "@/hooks/types";
 
 export const MANAGED_FILES: readonly string[] = [
   "ruff.toml",
@@ -45,8 +45,8 @@ export function protectsFile(command: string): string | null {
 
 export async function runProtectConfigs(): Promise<never> {
   const input = await readHookInput();
-  const bash = input.tool_input as unknown as BashToolInput;
-  const reason = protectsFile(bash.command ?? "");
+  const command = extractBashCommand(input.tool_input);
+  const reason = protectsFile(command);
   if (reason !== null) {
     deny(reason);
   }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -27,3 +27,12 @@ export interface WriteToolInput {
   old_str?: string;
   new_str?: string;
 }
+
+/**
+ * Extracts the `command` field from a Bash tool_input record.
+ * Returns an empty string when the field is absent or not a string.
+ */
+export function extractBashCommand(toolInput: Record<string, unknown>): string {
+  const cmd = toolInput.command;
+  return typeof cmd === "string" ? cmd : "";
+}


### PR DESCRIPTION
## Summary

- Replaces `as unknown as BashToolInput` double-cast in `dangerous-cmd.ts` and `protect-configs.ts` with a proper `extractBashCommand()` narrowing helper in `types.ts`. The helper reads `tool_input.command` from `Record<string, unknown>` with a `typeof` guard — no unsafe casts.
- Fixes silent `catch {}` in `format-stage.ts`: the spawn error is now logged to stderr so the failure cause is visible in hook output rather than silently swallowed.
- Build verified: `bun run build` produces `dist/ai-guardrails` (66MB standalone binary).
- 423 tests pass, lint clean, typecheck clean.

## Test plan

- [ ] `bun test` — 423 pass
- [ ] `bun run lint` — biome clean
- [ ] `bun run typecheck` — tsc clean
- [ ] `bun run build` — binary produced at `dist/ai-guardrails`
- [ ] Pre-commit hooks pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)