### PR TITLE
fix(dogfood): tsc PATH resolution and check error output in compiled binary

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -7,6 +7,10 @@ export async function runCheck(projectDir: string, flags: Record<string, unknown
   if (result.status === "error") {
     // Exit 1 = issues found, exit 2 = config/tool error
     const issueCount = result.issueCount ?? 0;
-    process.exit(issueCount > 0 ? 1 : 2);
+    if (issueCount === 0) {
+      process.stderr.write(`Error: ${result.message ?? "unknown error"}\n`);
+      process.exit(2);
+    }
+    process.exit(1);
   }
 }

--- a/src/runners/tsc.ts
+++ b/src/runners/tsc.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import type { ResolvedConfig } from "@/config/schema";
 import type { CommandRunner } from "@/infra/command-runner";
 import type { LintIssue } from "@/models/lint-issue";
@@ -61,18 +61,36 @@ export function parseTscOutput(output: string, projectDir: string): LintIssue[] 
   return issues;
 }
 
+// Returns the tsc executable path to use for the given project directory.
+// Prefers local node_modules/.bin/tsc so compiled binaries (which don't add
+// node_modules/.bin to PATH) still work. Falls back to "tsc" (global) when local
+// is absent. Returns null when neither is available.
+async function resolveTscPath(
+  projectDir: string,
+  commandRunner: CommandRunner,
+): Promise<string | null> {
+  const localTsc = join(projectDir, "node_modules", ".bin", "tsc");
+  const localResult = await commandRunner.run([localTsc, "--version"], { cwd: projectDir });
+  if (localResult.exitCode === 0) return localTsc;
+  const globalResult = await commandRunner.run(["tsc", "--version"]);
+  if (globalResult.exitCode === 0) return "tsc";
+  return null;
+}
+
 export const tscRunner: LinterRunner = {
   id: TSC_LINTER_ID,
   name: "TypeScript Compiler",
   configFile: null,
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
-    const result = await commandRunner.run(["tsc", "--version"]);
-    return result.exitCode === 0;
+    // Use cwd (".") as projectDir — callers don't supply it via the interface.
+    const tsc = await resolveTscPath(".", commandRunner);
+    return tsc !== null;
   },
 
   async run({ projectDir, commandRunner }: RunOptions): Promise<LintIssue[]> {
-    const result = await commandRunner.run(["tsc", "--noEmit", "--pretty", "false"], {
+    const tsc = (await resolveTscPath(projectDir, commandRunner)) ?? "tsc";
+    const result = await commandRunner.run([tsc, "--noEmit", "--pretty", "false"], {
       cwd: projectDir,
     });
     // tsc exits non-zero when errors exist — parse stdout+stderr

--- a/tests/runners/tsc.test.ts
+++ b/tests/runners/tsc.test.ts
@@ -80,10 +80,14 @@ describe("parseTscOutput", () => {
   });
 });
 
+const LOCAL_TSC = `${PROJECT_DIR}/node_modules/.bin/tsc`;
+
 describe("tscRunner.run", () => {
-  test("uses --noEmit --pretty false flags", async () => {
+  test("prefers local node_modules/.bin/tsc over global", async () => {
     const runner = new FakeCommandRunner();
-    runner.register(["tsc", "--noEmit", "--pretty", "false"], {
+    // resolveTscPath probes local tsc first
+    runner.register([LOCAL_TSC, "--version"], { stdout: "Version 5.8.0", stderr: "", exitCode: 0 });
+    runner.register([LOCAL_TSC, "--noEmit", "--pretty", "false"], {
       stdout: FIXTURE_TEXT,
       stderr: "",
       exitCode: 1, // tsc exits non-zero on errors
@@ -96,13 +100,36 @@ describe("tscRunner.run", () => {
       fileManager: new FakeFileManager(),
     });
 
-    expect(runner.calls[0]).toEqual(["tsc", "--noEmit", "--pretty", "false"]);
     expect(issues).toHaveLength(3);
+    // The run call uses the local tsc path
+    expect(runner.calls).toContainEqual([LOCAL_TSC, "--noEmit", "--pretty", "false"]);
+  });
+
+  test("falls back to global tsc when local is not found", async () => {
+    const runner = new FakeCommandRunner();
+    // Local tsc not available (exitCode 127)
+    runner.register([LOCAL_TSC, "--version"], { stdout: "", stderr: "not found", exitCode: 127 });
+    runner.register(["tsc", "--noEmit", "--pretty", "false"], {
+      stdout: FIXTURE_TEXT,
+      stderr: "",
+      exitCode: 1,
+    });
+
+    const issues = await tscRunner.run({
+      projectDir: PROJECT_DIR,
+      config: makeConfig(),
+      commandRunner: runner,
+      fileManager: new FakeFileManager(),
+    });
+
+    expect(issues).toHaveLength(3);
+    expect(runner.calls).toContainEqual(["tsc", "--noEmit", "--pretty", "false"]);
   });
 
   test("parses stdout and stderr combined for error lines", async () => {
     const runner = new FakeCommandRunner();
-    runner.register(["tsc", "--noEmit", "--pretty", "false"], {
+    runner.register([LOCAL_TSC, "--version"], { stdout: "Version 5.8.0", stderr: "", exitCode: 0 });
+    runner.register([LOCAL_TSC, "--noEmit", "--pretty", "false"], {
       stdout: "",
       stderr: FIXTURE_TEXT,
       exitCode: 1,
@@ -120,7 +147,8 @@ describe("tscRunner.run", () => {
 
   test("returns [] when no errors", async () => {
     const runner = new FakeCommandRunner();
-    runner.register(["tsc", "--noEmit", "--pretty", "false"], {
+    runner.register([LOCAL_TSC, "--version"], { stdout: "Version 5.8.0", stderr: "", exitCode: 0 });
+    runner.register([LOCAL_TSC, "--noEmit", "--pretty", "false"], {
       stdout: "",
       stderr: "",
       exitCode: 0,
@@ -137,16 +165,40 @@ describe("tscRunner.run", () => {
   });
 });
 
+// isAvailable uses cwd-relative path when no projectDir is supplied
+const LOCAL_TSC_CWD = "node_modules/.bin/tsc";
+
 describe("tscRunner.isAvailable", () => {
-  test("returns true when tsc --version exits 0", async () => {
+  test("returns true when local tsc exits 0", async () => {
     const runner = new FakeCommandRunner();
+    runner.register([LOCAL_TSC_CWD, "--version"], {
+      stdout: "Version 5.8.0",
+      stderr: "",
+      exitCode: 0,
+    });
+    const result = await tscRunner.isAvailable(runner);
+    expect(result).toBe(true);
+  });
+
+  test("returns true when global tsc exits 0 and local is absent", async () => {
+    const runner = new FakeCommandRunner();
+    runner.register([LOCAL_TSC_CWD, "--version"], {
+      stdout: "",
+      stderr: "not found",
+      exitCode: 127,
+    });
     runner.register(["tsc", "--version"], { stdout: "Version 5.8.0", stderr: "", exitCode: 0 });
     const result = await tscRunner.isAvailable(runner);
     expect(result).toBe(true);
   });
 
-  test("returns false when tsc --version exits non-zero", async () => {
+  test("returns false when both local and global tsc are absent", async () => {
     const runner = new FakeCommandRunner();
+    runner.register([LOCAL_TSC_CWD, "--version"], {
+      stdout: "",
+      stderr: "not found",
+      exitCode: 127,
+    });
     runner.register(["tsc", "--version"], { stdout: "", stderr: "not found", exitCode: 127 });
     const result = await tscRunner.isAvailable(runner);
     expect(result).toBe(false);


### PR DESCRIPTION
## Summary

Two bugs found during dogfood of the compiled `dist/ai-guardrails` binary:

- **tsc PATH resolution**: The compiled binary doesn't add `node_modules/.bin` to PATH, so `tsc` failed with "Executable not found". Introduced `resolveTscPath()` that prefers `{projectDir}/node_modules/.bin/tsc` and falls back to global `tsc`. Both `run()` and `isAvailable()` now use this shared resolver — eliminating the duplicated probe logic that existed in the original draft.
- **check error message swallowed**: When the check pipeline returned `status: "error"` with `issueCount === 0` (tool/config error), the command exited with code 2 but never printed the message. Now writes `Error: <message>` to stderr before exiting, consistent with all other commands.

## Test plan

- [ ] `bun test tests/runners/tsc.test.ts` — 14 tests, 0 failures (updated to cover local/global fallback paths)
- [ ] `bun test` — 425 tests, 0 failures
- [ ] `bun run lint && bun run typecheck` — clean
- [ ] `bun run build && ./dist/ai-guardrails check --project-dir .` — exits 1 (issues found), prints issues to stdout
- [ ] `./dist/ai-guardrails --help`, `./dist/ai-guardrails status --project-dir .`, `./dist/ai-guardrails generate --project-dir .` — all work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)