### PR TITLE
feat(init): prerequisite tool checking with install guidance

### DIFF
--- a/src/pipelines/check.ts
+++ b/src/pipelines/check.ts
@@ -30,6 +30,7 @@ export const checkPipeline: Pipeline = {
       config,
       commandRunner,
       fileManager,
+      cons,
     );
 
     const format = (ctx.flags.format as ReportFormat | undefined) ?? "text";

--- a/src/pipelines/init.ts
+++ b/src/pipelines/init.ts
@@ -3,6 +3,9 @@ import type { FileManager } from "@/infra/file-manager";
 import { PROJECT_CONFIG_PATH } from "@/models/paths";
 import type { Pipeline, PipelineContext, PipelineResult } from "@/pipelines/types";
 import { installPipeline } from "@/pipelines/install";
+import { checkPrerequisites } from "@/steps/check-prerequisites";
+import { detectLanguagesStep } from "@/steps/detect-languages";
+import { installPrerequisites } from "@/steps/install-prerequisites";
 import { dirname, join } from "node:path";
 import { stringify as stringifyToml } from "smol-toml";
 
@@ -76,7 +79,7 @@ function logInitStart(cons: Console, interactive: boolean): void {
 
 export const initPipeline: Pipeline = {
   async run(ctx: PipelineContext): Promise<PipelineResult> {
-    const { projectDir, fileManager, console: cons } = ctx;
+    const { projectDir, fileManager, commandRunner, console: cons } = ctx;
 
     const force = ctx.flags.force === true;
     const upgrade = ctx.flags.upgrade === true;
@@ -109,6 +112,18 @@ export const initPipeline: Pipeline = {
     cons.step(`Writing config: profile=${profile}...`);
     await writeProjectConfig(projectDir, profile, ignoreRules, fileManager);
     cons.success("Config written to .ai-guardrails/config.toml");
+
+    cons.step("Detecting languages...");
+    const { result: detectResult, languages } = await detectLanguagesStep(projectDir, fileManager);
+    if (detectResult.status === "error") {
+      return { status: "error", message: detectResult.message };
+    }
+    cons.success(detectResult.message);
+
+    cons.step("Checking prerequisites...");
+    const { report } = await checkPrerequisites(cons, commandRunner, languages);
+
+    await installPrerequisites(cons, commandRunner, report, projectDir);
 
     return installPipeline.run(ctx);
   },

--- a/src/runners/biome.ts
+++ b/src/runners/biome.ts
@@ -137,6 +137,10 @@ export const biomeRunner: LinterRunner = {
   id: BIOME_LINTER_ID,
   name: "Biome",
   configFile: "biome.json",
+  installHint: {
+    description: "TypeScript/JS linter and formatter",
+    npm: "npm install -D @biomejs/biome",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["biome", "--version"]);

--- a/src/runners/clang-tidy.ts
+++ b/src/runners/clang-tidy.ts
@@ -74,6 +74,11 @@ export const clangTidyRunner: LinterRunner = {
   id: "clang-tidy",
   name: "clang-tidy",
   configFile: ".clang-tidy",
+  installHint: {
+    description: "C/C++ linter",
+    brew: "brew install llvm",
+    apt: "sudo apt install clang-tidy",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["clang-tidy", "--version"]);

--- a/src/runners/clippy.ts
+++ b/src/runners/clippy.ts
@@ -82,6 +82,10 @@ export const clippyRunner: LinterRunner = {
   id: "clippy",
   name: "Clippy",
   configFile: null,
+  installHint: {
+    description: "Rust linter",
+    rustup: "rustup component add clippy",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["cargo", "clippy", "--version"]);

--- a/src/runners/codespell.ts
+++ b/src/runners/codespell.ts
@@ -58,6 +58,10 @@ export const codespellRunner: LinterRunner = {
   id: CODESPELL_LINTER_ID,
   name: "Codespell",
   configFile: ".codespellrc",
+  installHint: {
+    description: "Spell checker",
+    pip: "pip install codespell",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["codespell", "--version"]);

--- a/src/runners/golangci-lint.ts
+++ b/src/runners/golangci-lint.ts
@@ -81,6 +81,11 @@ export const golangciLintRunner: LinterRunner = {
   id: "golangci-lint",
   name: "golangci-lint",
   configFile: ".golangci.yml",
+  installHint: {
+    description: "Go meta-linter",
+    brew: "brew install golangci-lint",
+    go: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["golangci-lint", "--version"]);

--- a/src/runners/markdownlint.ts
+++ b/src/runners/markdownlint.ts
@@ -59,6 +59,10 @@ export const markdownlintRunner: LinterRunner = {
   id: MARKDOWNLINT_LINTER_ID,
   name: "markdownlint",
   configFile: ".markdownlint.jsonc",
+  installHint: {
+    description: "Markdown linter",
+    npm: "npm install -g markdownlint-cli2",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["markdownlint-cli2", "--version"]);

--- a/src/runners/pyright.ts
+++ b/src/runners/pyright.ts
@@ -112,6 +112,11 @@ export const pyrightRunner: LinterRunner = {
   id: "pyright",
   name: "Pyright",
   configFile: "pyrightconfig.json",
+  installHint: {
+    description: "Python type checker",
+    npm: "npm install -D pyright",
+    pip: "pip install pyright",
+  },
 
   async isAvailable(runner: CommandRunner): Promise<boolean> {
     const result = await runner.run(["pyright", "--version"]);

--- a/src/runners/ruff.ts
+++ b/src/runners/ruff.ts
@@ -198,6 +198,10 @@ export const ruffRunner: LinterRunner = {
   id: "ruff",
   name: "Ruff",
   configFile: "ruff.toml",
+  installHint: {
+    description: "Python linter and formatter",
+    pip: "pip install ruff",
+  },
 
   async isAvailable(runner: CommandRunner): Promise<boolean> {
     const result = await runner.run(["ruff", "--version"]);

--- a/src/runners/selene.ts
+++ b/src/runners/selene.ts
@@ -80,6 +80,11 @@ export const seleneRunner: LinterRunner = {
   id: SELENE_LINTER_ID,
   name: "Selene",
   configFile: "selene.toml",
+  installHint: {
+    description: "Lua linter",
+    cargo: "cargo install selene",
+    brew: "brew install selene",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["selene", "--version"]);

--- a/src/runners/shellcheck.ts
+++ b/src/runners/shellcheck.ts
@@ -86,6 +86,11 @@ export const shellcheckRunner: LinterRunner = {
   id: "shellcheck",
   name: "ShellCheck",
   configFile: null,
+  installHint: {
+    description: "Shell script linter",
+    brew: "brew install shellcheck",
+    apt: "sudo apt install shellcheck",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["shellcheck", "--version"]);

--- a/src/runners/shfmt.ts
+++ b/src/runners/shfmt.ts
@@ -46,6 +46,11 @@ export const shfmtRunner: LinterRunner = {
   id: "shfmt",
   name: "shfmt",
   configFile: null,
+  installHint: {
+    description: "Shell script formatter",
+    brew: "brew install shfmt",
+    go: "go install mvdan.cc/sh/v3/cmd/shfmt@latest",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     const result = await commandRunner.run(["shfmt", "--version"]);

--- a/src/runners/tsc.ts
+++ b/src/runners/tsc.ts
@@ -81,6 +81,10 @@ export const tscRunner: LinterRunner = {
   id: TSC_LINTER_ID,
   name: "TypeScript Compiler",
   configFile: null,
+  installHint: {
+    description: "TypeScript type checker",
+    npm: "npm install -D typescript",
+  },
 
   async isAvailable(commandRunner: CommandRunner): Promise<boolean> {
     // Use cwd (".") as projectDir — callers don't supply it via the interface.

--- a/src/runners/types.ts
+++ b/src/runners/types.ts
@@ -10,6 +10,25 @@ export interface RunOptions {
   fileManager: FileManager;
 }
 
+export interface InstallHint {
+  /** Short description of the tool, e.g. "Python linter and formatter" */
+  readonly description: string;
+  /** npm install command, e.g. "npm install -D typescript" */
+  readonly npm?: string;
+  /** pip install command, e.g. "pip install ruff" */
+  readonly pip?: string;
+  /** Homebrew install command, e.g. "brew install shellcheck" */
+  readonly brew?: string;
+  /** apt install command, e.g. "sudo apt install shellcheck" */
+  readonly apt?: string;
+  /** cargo install command, e.g. "cargo install selene" */
+  readonly cargo?: string;
+  /** go install command */
+  readonly go?: string;
+  /** rustup component command, e.g. "rustup component add clippy" */
+  readonly rustup?: string;
+}
+
 export interface LinterRunner {
   /** Stable identifier: "ruff", "pyright", "shellcheck", etc. */
   readonly id: string;
@@ -17,6 +36,8 @@ export interface LinterRunner {
   readonly name: string;
   /** Config file this runner manages, relative to project root. null = no config. */
   readonly configFile: string | null;
+  /** Install instructions for this tool */
+  readonly installHint: InstallHint;
   /** Check if the tool binary is reachable */
   isAvailable(commandRunner: CommandRunner): Promise<boolean>;
   /** Run the linter, return normalized issues */

--- a/src/steps/check-prerequisites.ts
+++ b/src/steps/check-prerequisites.ts
@@ -1,0 +1,67 @@
+import type { CommandRunner } from "@/infra/command-runner";
+import type { Console } from "@/infra/console";
+import type { LanguagePlugin } from "@/languages/types";
+import type { InstallHint, LinterRunner } from "@/runners/types";
+import { ok } from "@/models/step-result";
+import type { StepResult } from "@/models/step-result";
+
+export interface MissingTool {
+  runnerId: string;
+  hint: InstallHint;
+}
+
+export interface PrereqReport {
+  missing: MissingTool[];
+  available: string[];
+}
+
+/** Collect all unique runners across plugins, keyed by id. */
+function uniqueRunners(plugins: readonly LanguagePlugin[]): LinterRunner[] {
+  const seen = new Set<string>();
+  const runners: LinterRunner[] = [];
+  for (const plugin of plugins) {
+    for (const runner of plugin.runners()) {
+      if (!seen.has(runner.id)) {
+        seen.add(runner.id);
+        runners.push(runner);
+      }
+    }
+  }
+  return runners;
+}
+
+export async function checkPrerequisites(
+  cons: Console,
+  commandRunner: CommandRunner,
+  plugins: readonly LanguagePlugin[],
+): Promise<{ result: StepResult; report: PrereqReport }> {
+  const runners = uniqueRunners(plugins);
+
+  const results = await Promise.all(
+    runners.map(async (runner) => ({
+      runner,
+      isAvail: await runner.isAvailable(commandRunner),
+    })),
+  );
+
+  const missing: MissingTool[] = [];
+  const available: string[] = [];
+
+  for (const { runner, isAvail } of results) {
+    if (isAvail) {
+      available.push(runner.id);
+    } else {
+      missing.push({ runnerId: runner.id, hint: runner.installHint });
+    }
+  }
+
+  const report: PrereqReport = { missing, available };
+
+  if (missing.length === 0) {
+    cons.success(`All ${available.length} prerequisite tool(s) available`);
+  } else {
+    cons.warning(`${available.length} tool(s) available, ${missing.length} missing`);
+  }
+
+  return { result: ok("Prerequisite check complete"), report };
+}

--- a/src/steps/check-step.ts
+++ b/src/steps/check-step.ts
@@ -1,5 +1,6 @@
 import type { ResolvedConfig } from "@/config/schema";
 import type { CommandRunner } from "@/infra/command-runner";
+import type { Console } from "@/infra/console";
 import type { FileManager } from "@/infra/file-manager";
 import type { LanguagePlugin } from "@/languages/types";
 import type { LintIssue } from "@/models/lint-issue";
@@ -10,6 +11,7 @@ import type { RunOptions } from "@/runners/types";
 export interface CheckStepResult {
   result: StepResult;
   issues: LintIssue[];
+  skipped: number;
 }
 
 export async function checkStep(
@@ -18,16 +20,35 @@ export async function checkStep(
   config: ResolvedConfig,
   commandRunner: CommandRunner,
   fileManager: FileManager,
+  cons?: Console,
 ): Promise<CheckStepResult> {
   try {
     const opts: RunOptions = { projectDir, config, commandRunner, fileManager };
 
-    const allIssues = (
-      await Promise.all(
-        languages.flatMap((plugin) => plugin.runners().map((runner) => runner.run(opts))),
-      )
-    ).flat();
+    let skipped = 0;
+    const runnerResults = await Promise.all(
+      languages.flatMap((plugin) =>
+        plugin.runners().map(async (runner) => {
+          const available = await runner.isAvailable(commandRunner);
+          if (!available) {
+            cons?.warning(
+              `  ${runner.name} not found — skipping (${runner.installHint.description})`,
+            );
+            skipped++;
+            return [] as LintIssue[];
+          }
+          return runner.run(opts);
+        }),
+      ),
+    );
 
+    if (skipped > 0) {
+      cons?.warning(
+        `${skipped} runner(s) skipped — run \`ai-guardrails init\` to install missing tools`,
+      );
+    }
+
+    const allIssues = runnerResults.flat();
     const filtered = allIssues.filter((issue) => !config.isAllowed(issue.rule, issue.file));
 
     const msg = filtered.length === 0 ? "No new issues found" : `Found ${filtered.length} issue(s)`;
@@ -35,12 +56,14 @@ export async function checkStep(
     return {
       result: filtered.length > 0 ? error(msg) : ok(msg),
       issues: filtered,
+      skipped,
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {
       result: error(`Check failed: ${message}`),
       issues: [],
+      skipped: 0,
     };
   }
 }

--- a/src/steps/install-prerequisites.ts
+++ b/src/steps/install-prerequisites.ts
@@ -1,0 +1,76 @@
+import type { CommandRunner } from "@/infra/command-runner";
+import type { Console } from "@/infra/console";
+import type { InstallHint } from "@/runners/types";
+import { ok } from "@/models/step-result";
+import type { StepResult } from "@/models/step-result";
+import type { PrereqReport } from "@/steps/check-prerequisites";
+
+/** Pick the first available install command from a hint, in preference order. */
+function preferredInstallCmd(hint: InstallHint): string | undefined {
+  return hint.npm ?? hint.pip ?? hint.brew ?? hint.apt ?? hint.cargo ?? hint.go ?? hint.rustup;
+}
+
+function printMissingTools(cons: Console, missing: PrereqReport["missing"]): void {
+  cons.warning(`\nMissing tools (${missing.length}):`);
+  for (const tool of missing) {
+    cons.warning(`  ${tool.runnerId} — ${tool.hint.description}`);
+    const cmd = preferredInstallCmd(tool.hint);
+    if (cmd) {
+      cons.warning(`    Install: ${cmd}`);
+    }
+  }
+}
+
+async function runInstalls(
+  cons: Console,
+  commandRunner: CommandRunner,
+  missing: PrereqReport["missing"],
+  projectDir: string,
+): Promise<void> {
+  for (const tool of missing) {
+    const cmd = preferredInstallCmd(tool.hint);
+    if (!cmd) continue;
+    cons.info(`  Installing ${tool.runnerId}...`);
+    const parts = cmd.split(" ");
+    const result = await commandRunner.run(parts, { cwd: projectDir });
+    if (result.exitCode === 0) {
+      cons.info(`  ${tool.runnerId} installed`);
+    } else {
+      cons.warning(`  Failed to install ${tool.runnerId}. Run manually: ${cmd}`);
+    }
+  }
+}
+
+export async function installPrerequisites(
+  cons: Console,
+  commandRunner: CommandRunner,
+  report: PrereqReport,
+  projectDir: string,
+): Promise<StepResult> {
+  if (report.missing.length === 0) {
+    return ok("No missing prerequisites");
+  }
+
+  printMissingTools(cons, report.missing);
+
+  const isTTY = process.stdin.isTTY === true;
+
+  if (!isTTY) {
+    cons.warning("\nRun the commands above, then re-run `ai-guardrails init`.");
+    return ok("Missing tools listed — install manually and re-run init");
+  }
+
+  process.stdout.write("\nInstall missing tools now? [Y/n]: ");
+
+  for await (const line of console) {
+    const input = line.trim().toLowerCase();
+    if (input === "" || input === "y" || input === "yes") {
+      await runInstalls(cons, commandRunner, report.missing, projectDir);
+    } else {
+      cons.warning("Skipping install. Some checks will be unavailable.");
+    }
+    break;
+  }
+
+  return ok("Prerequisite install step complete");
+}

--- a/tests/steps/check-prerequisites.test.ts
+++ b/tests/steps/check-prerequisites.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { checkPrerequisites } from "@/steps/check-prerequisites";
+import type { LanguagePlugin } from "@/languages/types";
+import type { LinterRunner, RunOptions, InstallHint } from "@/runners/types";
+import type { LintIssue } from "@/models/lint-issue";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+import { FakeConsole } from "../fakes/fake-console";
+
+function makeHint(description: string, overrides?: Partial<InstallHint>): InstallHint {
+  return { description, ...overrides };
+}
+
+function makeRunner(id: string, available: boolean, hint?: Partial<InstallHint>): LinterRunner {
+  return {
+    id,
+    name: id,
+    configFile: null,
+    installHint: makeHint(`${id} tool`, hint),
+    async isAvailable() {
+      return available;
+    },
+    async run(_opts: RunOptions): Promise<LintIssue[]> {
+      return [];
+    },
+    generateConfig() {
+      return null;
+    },
+  };
+}
+
+function makePlugin(runners: LinterRunner[]): LanguagePlugin {
+  return {
+    id: "test",
+    name: "Test",
+    async detect() {
+      return true;
+    },
+    runners() {
+      return runners;
+    },
+  };
+}
+
+describe("checkPrerequisites", () => {
+  test("reports all available when every runner is present", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const plugin = makePlugin([makeRunner("ruff", true), makeRunner("pyright", true)]);
+
+    const { report } = await checkPrerequisites(cons, cr, [plugin]);
+
+    expect(report.missing).toHaveLength(0);
+    expect(report.available).toContain("ruff");
+    expect(report.available).toContain("pyright");
+    expect(cons.successes.length).toBeGreaterThan(0);
+  });
+
+  test("reports missing runners when tools are unavailable", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const plugin = makePlugin([
+      makeRunner("shellcheck", false, { brew: "brew install shellcheck" }),
+      makeRunner("shfmt", true),
+    ]);
+
+    const { report } = await checkPrerequisites(cons, cr, [plugin]);
+
+    expect(report.missing).toHaveLength(1);
+    expect(report.missing[0]?.runnerId).toBe("shellcheck");
+    expect(report.available).toContain("shfmt");
+    expect(cons.warnings.length).toBeGreaterThan(0);
+  });
+
+  test("deduplicates runners appearing in multiple plugins", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const sharedRunner = makeRunner("codespell", false, { pip: "pip install codespell" });
+    const plugin1 = makePlugin([sharedRunner]);
+    const plugin2 = makePlugin([sharedRunner]);
+
+    const { report } = await checkPrerequisites(cons, cr, [plugin1, plugin2]);
+
+    expect(report.missing).toHaveLength(1);
+    expect(report.missing[0]?.runnerId).toBe("codespell");
+  });
+
+  test("returns ok step result regardless of missing tools", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const plugin = makePlugin([makeRunner("clippy", false)]);
+
+    const { result } = await checkPrerequisites(cons, cr, [plugin]);
+
+    expect(result.status).toBe("ok");
+  });
+
+  test("handles empty plugin list", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+
+    const { report } = await checkPrerequisites(cons, cr, []);
+
+    expect(report.missing).toHaveLength(0);
+    expect(report.available).toHaveLength(0);
+  });
+});

--- a/tests/steps/check-step.test.ts
+++ b/tests/steps/check-step.test.ts
@@ -27,13 +27,16 @@ function makeIssue(overrides: Partial<LintIssue> = {}): LintIssue {
   };
 }
 
-function makeRunner(issues: LintIssue[]): LinterRunner {
+function makeRunner(issues: LintIssue[], available = true): LinterRunner {
   return {
     id: "test-runner",
     name: "Test Runner",
     configFile: null,
+    installHint: {
+      description: "Test tool",
+    },
     async isAvailable() {
-      return true;
+      return available;
     },
     async run(_opts: RunOptions): Promise<LintIssue[]> {
       return issues;
@@ -44,7 +47,7 @@ function makeRunner(issues: LintIssue[]): LinterRunner {
   };
 }
 
-function makePlugin(issues: LintIssue[]): LanguagePlugin {
+function makePlugin(issues: LintIssue[], available = true): LanguagePlugin {
   return {
     id: "test",
     name: "Test",
@@ -52,7 +55,7 @@ function makePlugin(issues: LintIssue[]): LanguagePlugin {
       return true;
     },
     runners() {
-      return [makeRunner(issues)];
+      return [makeRunner(issues, available)];
     },
   };
 }

--- a/tests/steps/install-prerequisites.test.ts
+++ b/tests/steps/install-prerequisites.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { installPrerequisites } from "@/steps/install-prerequisites";
+import type { PrereqReport } from "@/steps/check-prerequisites";
+import type { InstallHint } from "@/runners/types";
+import { FakeCommandRunner } from "../fakes/fake-command-runner";
+import { FakeConsole } from "../fakes/fake-console";
+
+function makeReport(missing: Array<{ id: string; hint: InstallHint }>): PrereqReport {
+  return {
+    missing: missing.map(({ id, hint }) => ({ runnerId: id, hint })),
+    available: [],
+  };
+}
+
+describe("installPrerequisites (non-TTY)", () => {
+  // All tests run in non-TTY (CI) context so the interactive branch is not exercised.
+
+  test("returns ok immediately when no tools are missing", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const report: PrereqReport = { missing: [], available: ["ruff"] };
+
+    const result = await installPrerequisites(cons, cr, report, "/project");
+
+    expect(result.status).toBe("ok");
+    expect(cr.calls).toHaveLength(0);
+  });
+
+  test("prints missing tools with install command on non-TTY", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const report = makeReport([
+      { id: "shellcheck", hint: { description: "Shell linter", brew: "brew install shellcheck" } },
+    ]);
+
+    // Ensure non-TTY path is taken (process.stdin.isTTY is undefined in test env)
+    const result = await installPrerequisites(cons, cr, report, "/project");
+
+    expect(result.status).toBe("ok");
+    // Should have warned about the missing tool and printed the hint
+    const allWarnings = cons.warnings.join("\n");
+    expect(allWarnings).toContain("shellcheck");
+    expect(allWarnings).toContain("brew install shellcheck");
+    // Should NOT have tried to run any install command
+    expect(cr.calls).toHaveLength(0);
+  });
+
+  test("prints first available install command in preference order (npm > pip > brew)", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const report = makeReport([
+      {
+        id: "pyright",
+        hint: {
+          description: "Python type checker",
+          npm: "npm install -D pyright",
+          pip: "pip install pyright",
+        },
+      },
+    ]);
+
+    await installPrerequisites(cons, cr, report, "/project");
+
+    const allWarnings = cons.warnings.join("\n");
+    expect(allWarnings).toContain("npm install -D pyright");
+  });
+
+  test("handles missing tool with no install command gracefully", async () => {
+    const cr = new FakeCommandRunner();
+    const cons = new FakeConsole();
+    const report = makeReport([{ id: "unknown-tool", hint: { description: "Some obscure tool" } }]);
+
+    const result = await installPrerequisites(cons, cr, report, "/project");
+
+    expect(result.status).toBe("ok");
+  });
+});

--- a/tests/steps/status-step.test.ts
+++ b/tests/steps/status-step.test.ts
@@ -34,6 +34,9 @@ function makeRunner(issues: LintIssue[]): LinterRunner {
     id: "test-runner",
     name: "Test Runner",
     configFile: null,
+    installHint: {
+      description: "Test tool",
+    },
     async isAvailable() {
       return true;
     },


### PR DESCRIPTION
## Summary

- Each `LinterRunner` now carries an `installHint` with per-package-manager install commands (npm, pip, brew, apt, cargo, go, rustup)
- New `checkPrerequisites` step: parallel `isAvailable()` checks with Set-based deduplication across plugins, returns `PrereqReport`
- New `installPrerequisites` step: on non-TTY prints install commands, on TTY prompts user to install missing tools interactively
- `init` pipeline: detect languages → check prerequisites → install prerequisites → run install pipeline
- `check-step`: warns and skips unavailable runners instead of erroring; adds `skipped` count to `CheckStepResult`

## Test plan

- [ ] `bun test` passes (434 tests, 0 failures)
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] Verify `checkPrerequisites` deduplicates runners across plugins
- [ ] Verify `installPrerequisites` prints install commands on non-TTY (CI)
- [ ] Verify `check-step` skips unavailable runners with warning instead of exit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)