### PR TITLE
fix(infra): command-runner timeout, dead verifyHash, Profile import, withHashHeader helper

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2,47 +2,54 @@ import { minimatch } from "minimatch";
 import { z } from "zod";
 
 const IgnoreEntrySchema = z.object({
-  rule: z.string().regex(/^[\w-]+\/[\w\-.]+$/, "Format: linter/RULE_CODE"),
-  reason: z.string().min(1, "Reason is required"),
+    rule: z.string().regex(/^[\w-]+\/[\w\-.]+$/, "Format: linter/RULE_CODE"),
+    reason: z.string().min(1, "Reason is required"),
 });
 
 const MachineConfigSchema = z.object({
-  profile: z.enum(["strict", "standard", "minimal"]).default("standard"),
-  ignore: z.array(IgnoreEntrySchema).default([]),
+    profile: z.enum(["strict", "standard", "minimal"]).default("standard"),
+    ignore: z.array(IgnoreEntrySchema).default([]),
 });
+
+export type Profile = "strict" | "standard" | "minimal";
+export const PROFILES = [
+    "strict",
+    "standard",
+    "minimal",
+] as const satisfies readonly Profile[];
 
 export type MachineConfig = z.infer<typeof MachineConfigSchema>;
 
 export { MachineConfigSchema };
 
 const ConfigValuesSchema = z
-  .object({
-    line_length: z.number().int().min(60).max(200).default(88),
-    indent_width: z
-      .number()
-      .int()
-      .refine((v) => v === 2 || v === 4, {
-        message: "indent_width must be 2 or 4",
-      })
-      .default(4),
-    python_version: z
-      .string()
-      .regex(/^\d+\.\d+$/)
-      .optional(),
-  })
-  .passthrough();
+    .object({
+        line_length: z.number().int().min(60).max(200).default(88),
+        indent_width: z
+            .number()
+            .int()
+            .refine((v) => v === 2 || v === 4, {
+                message: "indent_width must be 2 or 4",
+            })
+            .default(4),
+        python_version: z
+            .string()
+            .regex(/^\d+\.\d+$/)
+            .optional(),
+    })
+    .passthrough();
 
 const AllowEntrySchema = z.object({
-  rule: z.string().regex(/^[\w-]+\/[\w\-.]+$/),
-  glob: z.string().min(1),
-  reason: z.string().min(1),
+    rule: z.string().regex(/^[\w-]+\/[\w\-.]+$/),
+    glob: z.string().min(1),
+    reason: z.string().min(1),
 });
 
 const ProjectConfigSchema = z.object({
-  profile: z.enum(["strict", "standard", "minimal"]).optional(),
-  config: ConfigValuesSchema.default({}),
-  ignore: z.array(IgnoreEntrySchema).default([]),
-  allow: z.array(AllowEntrySchema).default([]),
+    profile: z.enum(["strict", "standard", "minimal"]).optional(),
+    config: ConfigValuesSchema.default({}),
+    ignore: z.array(IgnoreEntrySchema).default([]),
+    allow: z.array(AllowEntrySchema).default([]),
 });
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
@@ -50,50 +57,52 @@ export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
 export { ProjectConfigSchema };
 
 export interface ResolvedConfig {
-  profile: "strict" | "standard" | "minimal";
-  ignore: ReadonlyArray<{ rule: string; reason: string }>;
-  allow: ReadonlyArray<{ rule: string; glob: string; reason: string }>;
-  values: {
-    line_length: number;
-    indent_width: number;
-    python_version?: string;
-    [key: string]: unknown;
-  };
-  ignoredRules: ReadonlySet<string>;
-  isAllowed(rule: string, filePath: string): boolean;
+    profile: "strict" | "standard" | "minimal";
+    ignore: ReadonlyArray<{ rule: string; reason: string }>;
+    allow: ReadonlyArray<{ rule: string; glob: string; reason: string }>;
+    values: {
+        line_length: number;
+        indent_width: number;
+        python_version?: string;
+        [key: string]: unknown;
+    };
+    ignoredRules: ReadonlySet<string>;
+    isAllowed(rule: string, filePath: string): boolean;
 }
 
 export function buildResolvedConfig(
-  machine: MachineConfig,
-  project: ProjectConfig,
+    machine: MachineConfig,
+    project: ProjectConfig
 ): ResolvedConfig {
-  const profile = project.profile ?? machine.profile;
+    const profile = project.profile ?? machine.profile;
 
-  // Merge ignores: machine → project, deduped by rule
-  const ignoreMap = new Map<string, string>();
-  for (const entry of [...machine.ignore, ...project.ignore]) {
-    ignoreMap.set(entry.rule, entry.reason);
-  }
-  const ignore = Array.from(ignoreMap.entries()).map(([rule, reason]) => ({
-    rule,
-    reason,
-  }));
-  const ignoredRules = new Set(ignore.map((e) => e.rule));
-  const allow = project.allow;
-  // Cast via unknown: Zod adds `| undefined` to optional fields but
-  // exactOptionalPropertyTypes treats `python_version?: string` as absent-or-string.
-  // The runtime values are compatible; the type mismatch is a Zod inference quirk.
-  const values = project.config as unknown as ResolvedConfig["values"];
+    // Merge ignores: machine → project, deduped by rule
+    const ignoreMap = new Map<string, string>();
+    for (const entry of [...machine.ignore, ...project.ignore]) {
+        ignoreMap.set(entry.rule, entry.reason);
+    }
+    const ignore = Array.from(ignoreMap.entries()).map(([rule, reason]) => ({
+        rule,
+        reason,
+    }));
+    const ignoredRules = new Set(ignore.map((e) => e.rule));
+    const allow = project.allow;
+    // Cast via unknown: Zod adds `| undefined` to optional fields but
+    // exactOptionalPropertyTypes treats `python_version?: string` as absent-or-string.
+    // The runtime values are compatible; the type mismatch is a Zod inference quirk.
+    const values = project.config as unknown as ResolvedConfig["values"];
 
-  return {
-    profile,
-    ignore,
-    allow,
-    values,
-    ignoredRules,
-    isAllowed(rule: string, filePath: string): boolean {
-      if (ignoredRules.has(rule)) return true;
-      return allow.some((entry) => entry.rule === rule && minimatch(filePath, entry.glob));
-    },
-  };
+    return {
+        profile,
+        ignore,
+        allow,
+        values,
+        ignoredRules,
+        isAllowed(rule: string, filePath: string): boolean {
+            if (ignoredRules.has(rule)) return true;
+            return allow.some(
+                (entry) => entry.rule === rule && minimatch(filePath, entry.glob)
+            );
+        },
+    };
 }

--- a/src/generators/codespell.ts
+++ b/src/generators/codespell.ts
@@ -1,14 +1,13 @@
 import type { ResolvedConfig } from "@/config/schema";
 import type { ConfigGenerator } from "@/generators/types";
-import { makeHashHeader } from "@/utils/hash";
+import { withHashHeader } from "@/utils/hash";
 
 function renderCodespellrc(_config: ResolvedConfig): string {
     const content = `[codespell]
 skip = .git,*.lock,*.baseline,node_modules,.venv,venv,dist,build,*/tests/fixtures/*
 quiet-level = 2
 `;
-    const header = makeHashHeader(content);
-    return `${header}\n${content}`;
+    return withHashHeader(content);
 }
 
 export const codespellGenerator: ConfigGenerator = {

--- a/src/generators/editorconfig.ts
+++ b/src/generators/editorconfig.ts
@@ -1,9 +1,9 @@
 import type { ResolvedConfig } from "@/config/schema";
 import type { ConfigGenerator } from "@/generators/types";
-import { makeHashHeader } from "@/utils/hash";
+import { withHashHeader } from "@/utils/hash";
 
 function renderEditorconfig(_config: ResolvedConfig): string {
-  const content = `root = true
+    const content = `root = true
 
 [*]
 charset = utf-8
@@ -23,14 +23,13 @@ indent_style = tab
 [*.go]
 indent_style = tab
 `;
-  const header = makeHashHeader(content);
-  return `${header}\n${content}`;
+    return withHashHeader(content);
 }
 
 export const editorconfigGenerator: ConfigGenerator = {
-  id: "editorconfig",
-  configFile: ".editorconfig",
-  generate(config: ResolvedConfig): string {
-    return renderEditorconfig(config);
-  },
+    id: "editorconfig",
+    configFile: ".editorconfig",
+    generate(config: ResolvedConfig): string {
+        return renderEditorconfig(config);
+    },
 };

--- a/src/generators/ruff.ts
+++ b/src/generators/ruff.ts
@@ -1,11 +1,11 @@
 import type { ResolvedConfig } from "@/config/schema";
 import type { ConfigGenerator } from "@/generators/types";
-import { makeHashHeader } from "@/utils/hash";
+import { withHashHeader } from "@/utils/hash";
 
 function renderRuffToml(config: ResolvedConfig): string {
-  const lineLength = config.values.line_length ?? 88;
-  const indentWidth = config.values.indent_width ?? 4;
-  const content = `target-version = "py311"
+    const lineLength = config.values.line_length ?? 88;
+    const indentWidth = config.values.indent_width ?? 4;
+    const content = `target-version = "py311"
 line-length = ${lineLength}
 indent-width = ${indentWidth}
 fix = false
@@ -67,14 +67,13 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "lf"
 `;
-  const header = makeHashHeader(content);
-  return `${header}\n${content}`;
+    return withHashHeader(content);
 }
 
 export const ruffGenerator: ConfigGenerator = {
-  id: "ruff",
-  configFile: "ruff.toml",
-  generate(config: ResolvedConfig): string {
-    return renderRuffToml(config);
-  },
+    id: "ruff",
+    configFile: "ruff.toml",
+    generate(config: ResolvedConfig): string {
+        return renderRuffToml(config);
+    },
 };

--- a/src/infra/command-runner.ts
+++ b/src/infra/command-runner.ts
@@ -1,40 +1,46 @@
 export interface RunResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
+    stdout: string;
+    stderr: string;
+    exitCode: number;
 }
 
 export interface CommandRunner {
-  run(args: string[], opts?: { cwd?: string; timeout?: number }): Promise<RunResult>;
+    run(args: string[], opts?: { cwd?: string; timeout?: number }): Promise<RunResult>;
 }
 
 export class RealCommandRunner implements CommandRunner {
-  async run(args: string[], opts?: { cwd?: string; timeout?: number }): Promise<RunResult> {
-    const [cmd, ...rest] = args;
-    if (!cmd) {
-      return { stdout: "", stderr: "No command provided", exitCode: 1 };
+    async run(
+        args: string[],
+        opts?: { cwd?: string; timeout?: number }
+    ): Promise<RunResult> {
+        const [cmd, ...rest] = args;
+        if (!cmd) {
+            return { stdout: "", stderr: "No command provided", exitCode: 1 };
+        }
+
+        const cwd = opts?.cwd;
+        const proc =
+            cwd !== undefined
+                ? Bun.spawn([cmd, ...rest], { cwd, stdout: "pipe", stderr: "pipe" })
+                : Bun.spawn([cmd, ...rest], { stdout: "pipe", stderr: "pipe" });
+
+        let killTimer: ReturnType<typeof setTimeout> | undefined;
+        if (opts?.timeout !== undefined) {
+            killTimer = setTimeout(() => {
+                proc.kill();
+            }, opts.timeout);
+        }
+
+        const [stdout, stderr, exitCode] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+        ]);
+
+        if (killTimer !== undefined) {
+            clearTimeout(killTimer);
+        }
+
+        return { stdout, stderr, exitCode };
     }
-
-    const cwd = opts?.cwd;
-    const proc =
-      cwd !== undefined
-        ? Bun.spawn([cmd, ...rest], { cwd, stdout: "pipe", stderr: "pipe" })
-        : Bun.spawn([cmd, ...rest], { stdout: "pipe", stderr: "pipe" });
-
-    const [stdout, stderr] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
-
-    if (opts?.timeout !== undefined) {
-      const timeoutPromise = new Promise<number>((_, reject) =>
-        setTimeout(() => reject(new Error("Command timed out")), opts.timeout),
-      );
-      const exitCode = await Promise.race([proc.exited, timeoutPromise]);
-      return { stdout, stderr, exitCode };
-    }
-
-    const exitCode = await proc.exited;
-    return { stdout, stderr, exitCode };
-  }
 }

--- a/src/pipelines/init.ts
+++ b/src/pipelines/init.ts
@@ -1,130 +1,137 @@
+import { dirname, join } from "node:path";
+import { stringify as stringifyToml } from "smol-toml";
+import { PROFILES, type Profile } from "@/config/schema";
 import type { Console } from "@/infra/console";
 import type { FileManager } from "@/infra/file-manager";
 import { PROJECT_CONFIG_PATH } from "@/models/paths";
-import type { Pipeline, PipelineContext, PipelineResult } from "@/pipelines/types";
 import { installPipeline } from "@/pipelines/install";
+import type { Pipeline, PipelineContext, PipelineResult } from "@/pipelines/types";
 import { checkPrerequisites } from "@/steps/check-prerequisites";
 import { detectLanguagesStep } from "@/steps/detect-languages";
 import { installPrerequisites } from "@/steps/install-prerequisites";
-import { dirname, join } from "node:path";
-import { stringify as stringifyToml } from "smol-toml";
-
-type Profile = "strict" | "standard" | "minimal";
-
-const PROFILES: readonly Profile[] = ["strict", "standard", "minimal"] as const;
 
 function isProfile(value: string): value is Profile {
-  return (PROFILES as readonly string[]).includes(value);
+    return (PROFILES as readonly string[]).includes(value);
 }
 
 async function promptProfile(): Promise<Profile> {
-  process.stdout.write("Select profile [strict/standard/minimal] (default: standard): ");
-  for await (const line of console) {
-    const input = line.trim().toLowerCase();
-    if (input === "" || isProfile(input)) {
-      return (input || "standard") as Profile;
+    process.stdout.write(
+        "Select profile [strict/standard/minimal] (default: standard): "
+    );
+    for await (const line of console) {
+        const input = line.trim().toLowerCase();
+        if (input === "" || isProfile(input)) {
+            return (input || "standard") as Profile;
+        }
+        process.stdout.write("Invalid. Choose strict/standard/minimal: ");
     }
-    process.stdout.write("Invalid. Choose strict/standard/minimal: ");
-  }
-  return "standard";
+    return "standard";
 }
 
 async function promptIgnoreRules(): Promise<string[]> {
-  process.stdout.write("Rules to ignore (comma-separated linter/RULE, or press Enter to skip): ");
-  for await (const line of console) {
-    const input = line.trim();
-    if (!input) return [];
-    return input
-      .split(",")
-      .map((r) => r.trim())
-      .filter((r) => r.length > 0);
-  }
-  return [];
+    process.stdout.write(
+        "Rules to ignore (comma-separated linter/RULE, or press Enter to skip): "
+    );
+    for await (const line of console) {
+        const input = line.trim();
+        if (!input) return [];
+        return input
+            .split(",")
+            .map((r) => r.trim())
+            .filter((r) => r.length > 0);
+    }
+    return [];
 }
 
 async function writeProjectConfig(
-  projectDir: string,
-  profile: Profile,
-  ignoreRules: string[],
-  fileManager: FileManager,
+    projectDir: string,
+    profile: Profile,
+    ignoreRules: string[],
+    fileManager: FileManager
 ): Promise<void> {
-  const dest = join(projectDir, PROJECT_CONFIG_PATH);
-  await fileManager.mkdir(dirname(dest), { parents: true });
+    const dest = join(projectDir, PROJECT_CONFIG_PATH);
+    await fileManager.mkdir(dirname(dest), { parents: true });
 
-  const ignoreEntries = ignoreRules.map((rule) => ({
-    rule,
-    reason: "user-configured at init",
-  }));
+    const ignoreEntries = ignoreRules.map((rule) => ({
+        rule,
+        reason: "user-configured at init",
+    }));
 
-  const configData: Record<string, unknown> = { profile, ignore: ignoreEntries };
-  await fileManager.writeText(dest, stringifyToml(configData));
+    const configData: Record<string, unknown> = { profile, ignore: ignoreEntries };
+    await fileManager.writeText(dest, stringifyToml(configData));
 }
 
-async function checkConfigExists(projectDir: string, fileManager: FileManager): Promise<boolean> {
-  try {
-    await fileManager.readText(join(projectDir, PROJECT_CONFIG_PATH));
-    return true;
-  } catch {
-    return false;
-  }
+async function checkConfigExists(
+    projectDir: string,
+    fileManager: FileManager
+): Promise<boolean> {
+    try {
+        await fileManager.readText(join(projectDir, PROJECT_CONFIG_PATH));
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 function logInitStart(cons: Console, interactive: boolean): void {
-  if (interactive) {
-    cons.info("Running interactive init...");
-  } else {
-    cons.info("Running non-interactive init with defaults...");
-  }
+    if (interactive) {
+        cons.info("Running interactive init...");
+    } else {
+        cons.info("Running non-interactive init with defaults...");
+    }
 }
 
 export const initPipeline: Pipeline = {
-  async run(ctx: PipelineContext): Promise<PipelineResult> {
-    const { projectDir, fileManager, commandRunner, console: cons } = ctx;
+    async run(ctx: PipelineContext): Promise<PipelineResult> {
+        const { projectDir, fileManager, commandRunner, console: cons } = ctx;
 
-    const force = ctx.flags.force === true;
-    const upgrade = ctx.flags.upgrade === true;
+        const force = ctx.flags.force === true;
+        const upgrade = ctx.flags.upgrade === true;
 
-    const configExists = await checkConfigExists(projectDir, fileManager);
-    if (configExists && !force && !upgrade) {
-      return {
-        status: "error",
-        message:
-          ".ai-guardrails/config.toml already exists. Use --force to overwrite or --upgrade to refresh.",
-      };
-    }
+        const configExists = await checkConfigExists(projectDir, fileManager);
+        if (configExists && !force && !upgrade) {
+            return {
+                status: "error",
+                message:
+                    ".ai-guardrails/config.toml already exists. Use --force to overwrite or --upgrade to refresh.",
+            };
+        }
 
-    const isInteractive = process.stdin.isTTY === true;
-    logInitStart(cons, isInteractive);
+        const isInteractive = process.stdin.isTTY === true;
+        logInitStart(cons, isInteractive);
 
-    let profile: Profile = "standard";
-    let ignoreRules: string[] = [];
+        let profile: Profile = "standard";
+        let ignoreRules: string[] = [];
 
-    if (isInteractive) {
-      profile = await promptProfile();
-      ignoreRules = await promptIgnoreRules();
-    } else {
-      const flagProfile = ctx.flags.profile;
-      if (typeof flagProfile === "string" && isProfile(flagProfile)) {
-        profile = flagProfile;
-      }
-    }
+        if (isInteractive) {
+            profile = await promptProfile();
+            ignoreRules = await promptIgnoreRules();
+        } else {
+            const flagProfile = ctx.flags.profile;
+            if (typeof flagProfile === "string" && isProfile(flagProfile)) {
+                profile = flagProfile;
+            }
+        }
 
-    cons.step(`Writing config: profile=${profile}...`);
-    await writeProjectConfig(projectDir, profile, ignoreRules, fileManager);
-    cons.success("Config written to .ai-guardrails/config.toml");
+        cons.step(`Writing config: profile=${profile}...`);
+        await writeProjectConfig(projectDir, profile, ignoreRules, fileManager);
+        cons.success("Config written to .ai-guardrails/config.toml");
 
-    cons.step("Detecting languages...");
-    const { result: detectResult, languages } = await detectLanguagesStep(projectDir, fileManager);
-    if (detectResult.status === "error") {
-      return { status: "error", message: detectResult.message };
-    }
-    cons.success(detectResult.message);
+        cons.step("Detecting languages...");
+        const { result: detectResult, languages } = await detectLanguagesStep(
+            projectDir,
+            fileManager
+        );
+        if (detectResult.status === "error") {
+            return { status: "error", message: detectResult.message };
+        }
+        cons.success(detectResult.message);
 
-    cons.step("Checking prerequisites...");
-    const { report } = await checkPrerequisites(cons, commandRunner, languages);
+        cons.step("Checking prerequisites...");
+        const { report } = await checkPrerequisites(cons, commandRunner, languages);
 
-    await installPrerequisites(cons, commandRunner, report, projectDir);
+        await installPrerequisites(cons, commandRunner, report, projectDir);
 
-    return installPipeline.run(ctx);
-  },
+        return installPipeline.run(ctx);
+    },
 };

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -7,25 +7,14 @@ export const HASH_PREFIX = "# ai-guardrails:sha256=";
  * The hash covers the body text below the header line.
  */
 export function makeHashHeader(content: string): string {
-  const hash = createHash("sha256").update(content).digest("hex");
-  return `${HASH_PREFIX}${hash}`;
+    const hash = createHash("sha256").update(content).digest("hex");
+    return `${HASH_PREFIX}${hash}`;
 }
 
 /**
- * Verify that a file's hash header matches its content.
- * The file format is: `<header line>\n<body>`.
- * Returns false if the header is missing or the hash does not match.
+ * Prepend a hash header to the given content and return the combined string.
+ * The format is: `<header line>\n<content>`.
  */
-export function verifyHash(fileContent: string): boolean {
-  const newlineIndex = fileContent.indexOf("\n");
-  if (newlineIndex === -1) return false;
-
-  const headerLine = fileContent.slice(0, newlineIndex);
-  if (!headerLine.startsWith(HASH_PREFIX)) return false;
-
-  const storedHash = headerLine.slice(HASH_PREFIX.length);
-  const body = fileContent.slice(newlineIndex + 1);
-  const expectedHash = createHash("sha256").update(body).digest("hex");
-
-  return storedHash === expectedHash;
+export function withHashHeader(content: string): string {
+    return `${makeHashHeader(content)}\n${content}`;
 }

--- a/tests/generators/ruff.test.ts
+++ b/tests/generators/ruff.test.ts
@@ -1,55 +1,59 @@
 import { describe, expect, test } from "bun:test";
-import { ruffGenerator } from "@/generators/ruff";
-import { verifyHash } from "@/utils/hash";
 import type { ResolvedConfig } from "@/config/schema";
+import { ruffGenerator } from "@/generators/ruff";
+import { HASH_PREFIX, makeHashHeader } from "@/utils/hash";
 
 function makeConfig(overrides?: Partial<ResolvedConfig>): ResolvedConfig {
-  return {
-    profile: "standard",
-    ignore: [],
-    allow: [],
-    values: { line_length: 88, indent_width: 4 },
-    ignoredRules: new Set(),
-    isAllowed: () => false,
-    ...overrides,
-  };
+    return {
+        profile: "standard",
+        ignore: [],
+        allow: [],
+        values: { line_length: 88, indent_width: 4 },
+        ignoredRules: new Set(),
+        isAllowed: () => false,
+        ...overrides,
+    };
 }
 
 describe("ruffGenerator", () => {
-  test("id is ruff", () => {
-    expect(ruffGenerator.id).toBe("ruff");
-  });
+    test("id is ruff", () => {
+        expect(ruffGenerator.id).toBe("ruff");
+    });
 
-  test("configFile is ruff.toml", () => {
-    expect(ruffGenerator.configFile).toBe("ruff.toml");
-  });
+    test("configFile is ruff.toml", () => {
+        expect(ruffGenerator.configFile).toBe("ruff.toml");
+    });
 
-  test("output matches snapshot", () => {
-    const output = ruffGenerator.generate(makeConfig());
-    expect(output).toMatchSnapshot();
-  });
+    test("output matches snapshot", () => {
+        const output = ruffGenerator.generate(makeConfig());
+        expect(output).toMatchSnapshot();
+    });
 
-  test("output has valid hash header", () => {
-    const output = ruffGenerator.generate(makeConfig());
-    expect(verifyHash(output)).toBe(true);
-  });
+    test("output has valid hash header", () => {
+        const output = ruffGenerator.generate(makeConfig());
+        const newlineIdx = output.indexOf("\n");
+        const headerLine = output.slice(0, newlineIdx);
+        const body = output.slice(newlineIdx + 1);
+        expect(headerLine).toStartWith(HASH_PREFIX);
+        expect(headerLine).toBe(makeHashHeader(body));
+    });
 
-  test("output contains line-length from config", () => {
-    const output = ruffGenerator.generate(
-      makeConfig({ values: { line_length: 120, indent_width: 4 } }),
-    );
-    expect(output).toContain("line-length = 120");
-  });
+    test("output contains line-length from config", () => {
+        const output = ruffGenerator.generate(
+            makeConfig({ values: { line_length: 120, indent_width: 4 } })
+        );
+        expect(output).toContain("line-length = 120");
+    });
 
-  test("output contains indent-width from config", () => {
-    const output = ruffGenerator.generate(
-      makeConfig({ values: { line_length: 88, indent_width: 2 } }),
-    );
-    expect(output).toContain("indent-width = 2");
-  });
+    test("output contains indent-width from config", () => {
+        const output = ruffGenerator.generate(
+            makeConfig({ values: { line_length: 88, indent_width: 2 } })
+        );
+        expect(output).toContain("indent-width = 2");
+    });
 
-  test("output contains select all", () => {
-    const output = ruffGenerator.generate(makeConfig());
-    expect(output).toContain('select = ["ALL"]');
-  });
+    test("output contains select all", () => {
+        const output = ruffGenerator.generate(makeConfig());
+        expect(output).toContain('select = ["ALL"]');
+    });
 });

--- a/tests/utils/hash.test.ts
+++ b/tests/utils/hash.test.ts
@@ -1,68 +1,63 @@
 import { describe, expect, test } from "bun:test";
-import { HASH_PREFIX, makeHashHeader, verifyHash } from "@/utils/hash";
+import { HASH_PREFIX, makeHashHeader, withHashHeader } from "@/utils/hash";
 
 describe("HASH_PREFIX", () => {
-  test("has correct value", () => {
-    expect(HASH_PREFIX).toBe("# ai-guardrails:sha256=");
-  });
+    test("has correct value", () => {
+        expect(HASH_PREFIX).toBe("# ai-guardrails:sha256=");
+    });
 });
 
 describe("makeHashHeader", () => {
-  test("returns a line starting with the hash prefix", () => {
-    const header = makeHashHeader("some content");
-    expect(header).toStartWith(HASH_PREFIX);
-  });
+    test("returns a line starting with the hash prefix", () => {
+        const header = makeHashHeader("some content");
+        expect(header).toStartWith(HASH_PREFIX);
+    });
 
-  test("returns a 64-char hex hash after the prefix", () => {
-    const header = makeHashHeader("some content");
-    const hash = header.slice(HASH_PREFIX.length);
-    expect(hash).toMatch(/^[0-9a-f]{64}$/);
-  });
+    test("returns a 64-char hex hash after the prefix", () => {
+        const header = makeHashHeader("some content");
+        const hash = header.slice(HASH_PREFIX.length);
+        expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
 
-  test("same content produces same header", () => {
-    const a = makeHashHeader("content");
-    const b = makeHashHeader("content");
-    expect(a).toBe(b);
-  });
+    test("same content produces same header", () => {
+        const a = makeHashHeader("content");
+        const b = makeHashHeader("content");
+        expect(a).toBe(b);
+    });
 
-  test("different content produces different header", () => {
-    const a = makeHashHeader("content a");
-    const b = makeHashHeader("content b");
-    expect(a).not.toBe(b);
-  });
+    test("different content produces different header", () => {
+        const a = makeHashHeader("content a");
+        const b = makeHashHeader("content b");
+        expect(a).not.toBe(b);
+    });
 });
 
-describe("verifyHash", () => {
-  test("roundtrip: makeHashHeader + verifyHash returns true", () => {
-    const body = "line1\nline2\nline3\n";
-    const header = makeHashHeader(body);
-    const fullFile = `${header}\n${body}`;
-    expect(verifyHash(fullFile)).toBe(true);
-  });
+describe("withHashHeader", () => {
+    test("prepends the hash header line followed by a newline", () => {
+        const body = "line1\nline2\nline3\n";
+        const result = withHashHeader(body);
+        const [headerLine, ...rest] = result.split("\n");
+        expect(headerLine).toBe(makeHashHeader(body));
+        expect(rest.join("\n")).toBe(body);
+    });
 
-  test("returns false for tampered content", () => {
-    const body = "original content\n";
-    const header = makeHashHeader(body);
-    const tampered = `${header}\ntampered content\n`;
-    expect(verifyHash(tampered)).toBe(false);
-  });
+    test("header in output matches the body content hash", () => {
+        const body = "original content\n";
+        const result = withHashHeader(body);
+        const expectedHeader = makeHashHeader(body);
+        expect(result.startsWith(expectedHeader)).toBe(true);
+    });
 
-  test("returns false for file with no hash header", () => {
-    const content = "no header here\n";
-    expect(verifyHash(content)).toBe(false);
-  });
+    test("works with empty body", () => {
+        const result = withHashHeader("");
+        const expectedHeader = makeHashHeader("");
+        expect(result).toBe(`${expectedHeader}\n`);
+    });
 
-  test("returns false for file with empty content after header", () => {
-    const header = makeHashHeader("");
-    const fileWithJustHeader = `${header}\n`;
-    // body is "" so hash of "" should match
-    expect(verifyHash(fileWithJustHeader)).toBe(true);
-  });
-
-  test("handles multi-line file content correctly", () => {
-    const body = `${Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n")}\n`;
-    const header = makeHashHeader(body);
-    const fullFile = `${header}\n${body}`;
-    expect(verifyHash(fullFile)).toBe(true);
-  });
+    test("handles multi-line file content correctly", () => {
+        const body = `${Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n")}\n`;
+        const result = withHashHeader(body);
+        const expectedHeader = makeHashHeader(body);
+        expect(result).toBe(`${expectedHeader}\n${body}`);
+    });
 });


### PR DESCRIPTION
## Summary

- **command-runner.ts**: Restructure timeout handling — set a `setTimeout` that kills the process, then collect `stdout`/`stderr`/`exitCode` in a single `Promise.all`. Previously the code drained streams first (which requires the process to exit), making the `Promise.race` timeout branch unreachable.
- **hash.ts**: Remove unused `verifyHash()` export; add `withHashHeader(content)` helper that encapsulates the repeated `makeHashHeader + \`${header}\n${content}\`` two-step pattern used across all generators.
- **schema.ts**: Export `Profile` type and `PROFILES` const so consumers can import them instead of re-declaring locally.
- **init.ts**: Import `Profile`/`PROFILES` from `@/config/schema` — removes local duplicate declarations.
- **generators** (ruff, editorconfig, codespell): Replace two-step hash header pattern with `withHashHeader()`.
- **tests**: Update `hash.test.ts` (replace `verifyHash` suite with `withHashHeader` suite) and `ruff.test.ts` (use `makeHashHeader` for header validation).

## Test plan

- [ ] `bun test` — all previously-passing tests still pass; no new failures introduced
- [ ] `grep -r "verifyHash" src/` returns zero results
- [ ] `grep -r "makeHashHeader" src/generators/` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)