### PR TITLE
fix(helpers): safeParseJson utility, parallel globs, golangci memoize, deny context

### DIFF
--- a/src/hooks/dangerous-cmd.ts
+++ b/src/hooks/dangerous-cmd.ts
@@ -16,7 +16,7 @@ export async function runDangerousCmd(): Promise<never> {
     const command = extractBashCommand(input.tool_input);
     const reason = isDangerous(command);
     if (reason !== null) {
-        deny(reason);
+        deny(`[dangerous-cmd] ${reason}`);
     }
     allow();
 }

--- a/src/hooks/protect-configs.ts
+++ b/src/hooks/protect-configs.ts
@@ -48,7 +48,7 @@ export async function runProtectConfigs(): Promise<never> {
     const command = extractBashCommand(input.tool_input);
     const reason = protectsFile(command);
     if (reason !== null) {
-        deny(reason);
+        deny(`[protect-configs] ${reason}`);
     }
     allow();
 }

--- a/src/languages/cpp.ts
+++ b/src/languages/cpp.ts
@@ -8,10 +8,11 @@ export const cppPlugin: LanguagePlugin = {
 
     async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
         if (await fileManager.exists(`${projectDir}/CMakeLists.txt`)) return true;
-        const cppFiles = await fileManager.glob("**/*.cpp", projectDir);
-        if (cppFiles.length > 0) return true;
-        const cFiles = await fileManager.glob("**/*.c", projectDir);
-        return cFiles.length > 0;
+        const [cppFiles, cFiles] = await Promise.all([
+            fileManager.glob("**/*.cpp", projectDir),
+            fileManager.glob("**/*.c", projectDir),
+        ]);
+        return cppFiles.length > 0 || cFiles.length > 0;
     },
 
     runners(): LinterRunner[] {

--- a/src/languages/dotnet.ts
+++ b/src/languages/dotnet.ts
@@ -6,10 +6,11 @@ export const dotnetPlugin: LanguagePlugin = {
     name: ".NET",
 
     async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
-        const csprojFiles = await fileManager.glob("**/*.csproj", projectDir);
-        if (csprojFiles.length > 0) return true;
-        const slnFiles = await fileManager.glob("**/*.sln", projectDir);
-        return slnFiles.length > 0;
+        const [csprojFiles, slnFiles] = await Promise.all([
+            fileManager.glob("**/*.csproj", projectDir),
+            fileManager.glob("**/*.sln", projectDir),
+        ]);
+        return csprojFiles.length > 0 || slnFiles.length > 0;
     },
 
     runners(): LinterRunner[] {

--- a/src/languages/shell.ts
+++ b/src/languages/shell.ts
@@ -8,12 +8,12 @@ export const shellPlugin: LanguagePlugin = {
     name: "Shell",
 
     async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
-        const shFiles = await fileManager.glob("**/*.sh", projectDir);
-        if (shFiles.length > 0) return true;
-        const bashFiles = await fileManager.glob("**/*.bash", projectDir);
-        if (bashFiles.length > 0) return true;
-        const zshFiles = await fileManager.glob("**/*.zsh", projectDir);
-        return zshFiles.length > 0;
+        const [shFiles, bashFiles, zshFiles] = await Promise.all([
+            fileManager.glob("**/*.sh", projectDir),
+            fileManager.glob("**/*.bash", projectDir),
+            fileManager.glob("**/*.zsh", projectDir),
+        ]);
+        return shFiles.length > 0 || bashFiles.length > 0 || zshFiles.length > 0;
     },
 
     runners(): LinterRunner[] {

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -9,10 +9,11 @@ export const typescriptPlugin: LanguagePlugin = {
 
     async detect({ projectDir, fileManager }: DetectOptions): Promise<boolean> {
         if (await fileManager.exists(`${projectDir}/package.json`)) return true;
-        const tsFiles = await fileManager.glob("**/*.ts", projectDir);
-        if (tsFiles.length > 0) return true;
-        const jsFiles = await fileManager.glob("**/*.js", projectDir);
-        return jsFiles.length > 0;
+        const [tsFiles, jsFiles] = await Promise.all([
+            fileManager.glob("**/*.ts", projectDir),
+            fileManager.glob("**/*.js", projectDir),
+        ]);
+        return tsFiles.length > 0 || jsFiles.length > 0;
     },
 
     runners(): LinterRunner[] {

--- a/src/runners/biome.ts
+++ b/src/runners/biome.ts
@@ -3,6 +3,7 @@ import type { CommandRunner } from "@/infra/command-runner";
 import type { LintIssue } from "@/models/lint-issue";
 import { computeFingerprint } from "@/models/lint-issue";
 import type { LinterRunner, RunOptions } from "@/runners/types";
+import { safeParseJson } from "@/utils/parse";
 
 const BIOME_LINTER_ID = "biome";
 const BIOME_RULE_PREFIX = "biome/";
@@ -57,12 +58,8 @@ export function parseBiomeRdjsonOutput(
     stdout: string,
     projectDir: string
 ): LintIssue[] {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(stdout);
-    } catch {
-        return [];
-    }
+    const parsed = safeParseJson(stdout);
+    if (parsed === null) return [];
 
     if (!isRdjsonOutput(parsed)) {
         return [];

--- a/src/runners/golangci-lint.ts
+++ b/src/runners/golangci-lint.ts
@@ -3,6 +3,7 @@ import type { CommandRunner } from "@/infra/command-runner";
 import type { LintIssue } from "@/models/lint-issue";
 import { computeFingerprint } from "@/models/lint-issue";
 import type { LinterRunner, RunOptions } from "@/runners/types";
+import { safeParseJson } from "@/utils/parse";
 
 interface GolangciIssue {
     FromLinter: string;
@@ -27,12 +28,8 @@ function isGolangciOutput(value: unknown): value is GolangciOutput {
  * Handles null Issues array (no issues found).
  */
 export function parseGolangciOutput(json: string, projectDir: string): LintIssue[] {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(json);
-    } catch {
-        return [];
-    }
+    const parsed = safeParseJson(json);
+    if (parsed === null) return [];
 
     if (!isGolangciOutput(parsed)) return [];
 
@@ -67,7 +64,7 @@ export function parseGolangciOutput(json: string, projectDir: string): LintIssue
  * Detect golangci-lint version and choose the appropriate JSON output flag.
  * v1.64+ uses --output.json.path=stdout; older versions use --out-format=json.
  */
-async function detectJsonFlag(
+async function detectVersionFlag(
     commandRunner: CommandRunner,
     cwd: string
 ): Promise<string> {
@@ -77,6 +74,23 @@ async function detectJsonFlag(
     const minor = Number.parseInt(match?.[2] ?? "0", 10);
     const isV164Plus = major > 1 || (major === 1 && minor >= 64);
     return isV164Plus ? "--output.json.path=stdout" : "--out-format=json";
+}
+
+let cachedVersionFlagPromise: Promise<string> | undefined;
+
+async function getVersionFlag(
+    commandRunner: CommandRunner,
+    cwd: string
+): Promise<string> {
+    if (cachedVersionFlagPromise === undefined) {
+        cachedVersionFlagPromise = detectVersionFlag(commandRunner, cwd);
+    }
+    return cachedVersionFlagPromise;
+}
+
+/** Reset the version flag cache. Exported for test isolation. */
+export function resetVersionFlagCache(): void {
+    cachedVersionFlagPromise = undefined;
 }
 
 export const golangciLintRunner: LinterRunner = {
@@ -96,7 +110,7 @@ export const golangciLintRunner: LinterRunner = {
 
     async run(opts: RunOptions): Promise<LintIssue[]> {
         const { projectDir, commandRunner } = opts;
-        const jsonFlag = await detectJsonFlag(commandRunner, projectDir);
+        const jsonFlag = await getVersionFlag(commandRunner, projectDir);
         const result = await commandRunner.run(
             ["golangci-lint", "run", jsonFlag, "./..."],
             {

--- a/src/runners/pyright.ts
+++ b/src/runners/pyright.ts
@@ -2,6 +2,7 @@ import type { CommandRunner } from "@/infra/command-runner";
 import type { LintIssue } from "@/models/lint-issue";
 import { computeFingerprint } from "@/models/lint-issue";
 import type { LinterRunner, RunOptions } from "@/runners/types";
+import { safeParseJson } from "@/utils/parse";
 
 interface PyrightRange {
     start: { line: number; character: number };
@@ -57,12 +58,8 @@ function isPyrightOutput(value: unknown): value is PyrightOutput {
 export function parsePyrightOutput(stdout: string): LintIssue[] {
     if (!stdout.trim()) return [];
 
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(stdout);
-    } catch {
-        return [];
-    }
+    const parsed = safeParseJson(stdout);
+    if (parsed === null) return [];
 
     if (!isPyrightOutput(parsed)) return [];
 

--- a/src/runners/ruff.ts
+++ b/src/runners/ruff.ts
@@ -3,6 +3,7 @@ import type { CommandRunner } from "@/infra/command-runner";
 import type { LintIssue } from "@/models/lint-issue";
 import { computeFingerprint } from "@/models/lint-issue";
 import type { LinterRunner, RunOptions } from "@/runners/types";
+import { safeParseJson } from "@/utils/parse";
 
 // Codes starting with E or F are errors; everything else is a warning.
 const ERROR_PREFIXES = ["E", "F"] as const;
@@ -40,13 +41,7 @@ function isRuffItem(value: unknown): value is RuffItem {
 export function parseRuffOutput(stdout: string, _config: ResolvedConfig): LintIssue[] {
     if (!stdout.trim()) return [];
 
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(stdout);
-    } catch {
-        return [];
-    }
-
+    const parsed = safeParseJson(stdout);
     if (!Array.isArray(parsed)) return [];
 
     const issues: LintIssue[] = [];

--- a/src/runners/selene.ts
+++ b/src/runners/selene.ts
@@ -3,6 +3,7 @@ import type { CommandRunner } from "@/infra/command-runner";
 import type { LintIssue } from "@/models/lint-issue";
 import { computeFingerprint } from "@/models/lint-issue";
 import type { LinterRunner, RunOptions } from "@/runners/types";
+import { safeParseJson } from "@/utils/parse";
 
 const SELENE_LINTER_ID = "selene";
 const SELENE_RULE_PREFIX = "selene/";
@@ -35,13 +36,7 @@ function isSeleneEntry(value: unknown): value is SeleneEntry {
  * Returns [] on malformed or empty input.
  */
 export function parseSeleneOutput(stdout: string, projectDir: string): LintIssue[] {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(stdout);
-    } catch {
-        return [];
-    }
-
+    const parsed = safeParseJson(stdout);
     if (!Array.isArray(parsed)) return [];
 
     const issues: LintIssue[] = [];

--- a/src/runners/shellcheck.ts
+++ b/src/runners/shellcheck.ts
@@ -4,6 +4,7 @@ import type { FileManager } from "@/infra/file-manager";
 import type { LintIssue } from "@/models/lint-issue";
 import { computeFingerprint } from "@/models/lint-issue";
 import type { LinterRunner, RunOptions } from "@/runners/types";
+import { safeParseJson } from "@/utils/parse";
 
 /** Shape of a single comment in shellcheck --format=json1 output */
 interface ShellcheckComment {
@@ -25,12 +26,8 @@ interface ShellcheckOutput {
  * Returns [] on malformed/empty input.
  */
 export function parseShellcheckOutput(stdout: string, projectDir: string): LintIssue[] {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(stdout);
-    } catch {
-        return [];
-    }
+    const parsed = safeParseJson(stdout);
+    if (parsed === null) return [];
 
     if (!isShellcheckOutput(parsed)) return [];
 

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,0 +1,11 @@
+/**
+ * Parse JSON text, returning null on any parse error.
+ * Use this instead of try/catch around JSON.parse.
+ */
+export function safeParseJson(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}

--- a/tests/runners/golangci-lint.test.ts
+++ b/tests/runners/golangci-lint.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
 import type { ResolvedConfig } from "@/config/schema";
-import { golangciLintRunner, parseGolangciOutput } from "@/runners/golangci-lint";
+import {
+    golangciLintRunner,
+    parseGolangciOutput,
+    resetVersionFlagCache,
+} from "@/runners/golangci-lint";
 import { FakeCommandRunner } from "../fakes/fake-command-runner";
 import { FakeFileManager } from "../fakes/fake-file-manager";
 
@@ -69,6 +73,10 @@ describe("parseGolangciOutput", () => {
 });
 
 describe("golangciLintRunner.run", () => {
+    beforeEach(() => {
+        resetVersionFlagCache();
+    });
+
     test("uses --output.json.path=stdout flag for version >= 1.64", async () => {
         const runner = new FakeCommandRunner();
         runner.register(["golangci-lint", "--version"], {


### PR DESCRIPTION
## Summary
- Add `src/utils/parse.ts` with `safeParseJson()` — replaces inline try/catch blocks in 6 runners (biome, golangci-lint, pyright, ruff, selene, shellcheck)
- Parallelize glob calls in shell, typescript, cpp, dotnet language plugins using `Promise.all`
- Cache golangci-lint version detection at Promise level to prevent concurrent stampede
- Prefix `deny()` messages in dangerous-cmd and protect-configs hooks with hook name for context

Supersedes #91 (same changes, rebased cleanly on top of #90/#92/#93).

🤖 Generated with [Claude Code](https://claude.com/claude-code)