### PR TITLE
Sync cc-review workflows — fix hook loading

### DIFF
--- a/.github/workflows/cc-review-interactive.yml
+++ b/.github/workflows/cc-review-interactive.yml
@@ -42,6 +42,7 @@ jobs:
           cp -r /tmp/cc-review-bot/.claude/skills .claude/
           cp -r /tmp/cc-review-bot/.claude/hooks .claude/
           cp /tmp/cc-review-bot/.claude/CLAUDE.md .claude/CLAUDE.md
+          cp /tmp/cc-review-bot/.claude/settings.json .claude/settings.json
 
       - name: Fetch memory branch
         run: git fetch origin claude-reviewer/memory:claude-reviewer/memory 2>/dev/null || true

--- a/.github/workflows/cc-review.yml
+++ b/.github/workflows/cc-review.yml
@@ -57,6 +57,7 @@ jobs:
           cp -r /tmp/cc-review-bot/.claude/skills .claude/
           cp -r /tmp/cc-review-bot/.claude/hooks .claude/
           cp /tmp/cc-review-bot/.claude/CLAUDE.md .claude/CLAUDE.md
+          cp /tmp/cc-review-bot/.claude/settings.json .claude/settings.json
 
       - name: Fetch memory branch
         run: git fetch origin claude-reviewer/memory:claude-reviewer/memory 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Copy `settings.json` in CI so PreToolUse hooks actually load (hooks were in plugin-only location before)
- Affects both auto-review and interactive workflows

## Test plan
- [x] Integration tests pass (24/24) in cc-review repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)