### PR TITLE
fix(steps): use injected Console in report-step

### DIFF
--- a/src/steps/report-step.ts
+++ b/src/steps/report-step.ts
@@ -20,7 +20,7 @@ export async function reportStep(
     if (sarifOutputPath) {
       await fileManager.writeText(sarifOutputPath, sarifJson);
     } else {
-      process.stdout.write(`${sarifJson}\n`);
+      console.info(sarifJson);
     }
   }
 


### PR DESCRIPTION
Replaces `process.stdout.write(sarifJson)` with `console.info(sarifJson)` in report-step.ts. The `console` parameter already shadows global — line 29 was already correct. Only line 23 needed fixing.