### PR TITLE
refactor(steps): remove shell-quote dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@commander-js/extra-typings": "^13.0.0",
         "@questi0nm4rk/shell-ast": "^0.1.0",
         "minimatch": "^10.0.0",
-        "shell-quote": "^1.8.3",
         "smol-toml": "^1.5.1",
         "zod": "^3.24.0",
       },
@@ -16,7 +15,6 @@
         "@biomejs/biome": "^2.4.6",
         "@types/bun": "^1.3.10",
         "@types/minimatch": "^5.1.0",
-        "@types/shell-quote": "^1.7.5",
         "typescript": "^5.8.0",
       },
     },
@@ -50,8 +48,6 @@
 
     "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
-    "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
-
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
@@ -61,8 +57,6 @@
     "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
-
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@commander-js/extra-typings": "^13.0.0",
     "@questi0nm4rk/shell-ast": "^0.1.0",
     "minimatch": "^10.0.0",
-    "shell-quote": "^1.8.3",
     "smol-toml": "^1.5.1",
     "zod": "^3.24.0"
   },
@@ -26,7 +25,6 @@
     "@biomejs/biome": "^2.4.6",
     "@types/bun": "^1.3.10",
     "@types/minimatch": "^5.1.0",
-    "@types/shell-quote": "^1.7.5",
     "typescript": "^5.8.0"
   }
 }

--- a/src/steps/install-prerequisites.ts
+++ b/src/steps/install-prerequisites.ts
@@ -1,5 +1,5 @@
 import { createInterface } from "node:readline";
-import { parse as shellParse } from "shell-quote";
+
 import type { CommandRunner } from "@/infra/command-runner";
 import type { Console } from "@/infra/console";
 import type { StepResult } from "@/models/step-result";
@@ -41,7 +41,9 @@ async function runInstalls(
     const cmd = preferredInstallCmd(tool.hint);
     if (!cmd) continue;
     cons.info(`  Installing ${tool.runnerId}...`);
-    const parts = shellParse(cmd).filter((t): t is string => typeof t === "string");
+    // Install hints are hardcoded simple commands (no quoting or escaping needed).
+    // See src/runners/*.ts installHint fields for the full list.
+    const parts = cmd.split(" ");
     const result = await commandRunner.run(parts, { cwd: projectDir });
     if (result.exitCode === 0) {
       cons.info(`  ${tool.runnerId} installed`);


### PR DESCRIPTION
## Summary
- Replace `shell-quote` parsing with `cmd.split(" ")` in `install-prerequisites.ts` — all install hint strings are hardcoded simple commands with no quoting or escaping
- Remove `shell-quote` and `@types/shell-quote` from dependencies

## Test plan
- [x] `bun run typecheck` passes
- [x] All 570 tests pass (`bun test`)
- [x] No other `shell-quote` imports in `src/` or `tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)