### PR TITLE
test(generators): snapshot tests for 6 untested generators

### DIFF
--- a/tests/generators/__snapshots__/agent-rules.test.ts.snap
+++ b/tests/generators/__snapshots__/agent-rules.test.ts.snap
@@ -1,0 +1,111 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`agentRulesGenerator generate output matches snapshot 1`] = `
+"<!-- ai-guardrails:sha256=420431e9fd3fd7de3a689bf841d828c3bb7c3ff1af1d1c94a2199de44673bb96 -->
+# AI Agent Rules
+
+## Core Principles
+
+- Never push directly to main — always open a PR
+- Never commit secrets, credentials, or .env files
+- Run tests before committing: all tests must pass
+- Fix ALL review findings including nitpicks
+- Never batch-resolve review threads without reading each one
+
+## Git Workflow
+
+- Conventional commit messages: feat:, fix:, refactor:, chore:, test:, docs:
+- Create feature branches: git checkout -b feat/<name>
+- Keep commits focused — one logical change per commit
+
+## Code Quality
+
+- No any — use unknown + type narrowing at boundaries
+- No non-null assertions (!) — handle undefined explicitly
+- No commented-out code — delete it or open an issue
+- No TODO without an issue reference
+
+## Security
+
+- Never log secrets, tokens, or passwords
+- Never eval() user input
+- Never trust user-provided paths without sanitization
+"
+`;
+
+exports[`buildAgentRules buildAgentRules claude matches snapshot 1`] = `
+"# AI Agent Rules
+
+## Core Principles
+
+- Never push directly to main — always open a PR
+- Never commit secrets, credentials, or .env files
+- Run tests before committing: all tests must pass
+- Fix ALL review findings including nitpicks
+- Never batch-resolve review threads without reading each one
+
+## Git Workflow
+
+- Conventional commit messages: feat:, fix:, refactor:, chore:, test:, docs:
+- Create feature branches: git checkout -b feat/<name>
+- Keep commits focused — one logical change per commit
+
+## Code Quality
+
+- No any — use unknown + type narrowing at boundaries
+- No non-null assertions (!) — handle undefined explicitly
+- No commented-out code — delete it or open an issue
+- No TODO without an issue reference
+
+## Security
+
+- Never log secrets, tokens, or passwords
+- Never eval() user input
+- Never trust user-provided paths without sanitization
+
+## Claude Code Specific
+
+- Read CLAUDE.md at the start of each session
+- Use PreToolUse hooks — they protect configs and catch dangerous commands
+- Never disable the hook system to bypass restrictions
+- The deny list in .claude/settings.json exists for safety — don't circumvent it
+"
+`;
+
+exports[`buildAgentRules buildAgentRules cursor matches snapshot 1`] = `
+"# AI Agent Rules
+
+## Core Principles
+
+- Never push directly to main — always open a PR
+- Never commit secrets, credentials, or .env files
+- Run tests before committing: all tests must pass
+- Fix ALL review findings including nitpicks
+- Never batch-resolve review threads without reading each one
+
+## Git Workflow
+
+- Conventional commit messages: feat:, fix:, refactor:, chore:, test:, docs:
+- Create feature branches: git checkout -b feat/<name>
+- Keep commits focused — one logical change per commit
+
+## Code Quality
+
+- No any — use unknown + type narrowing at boundaries
+- No non-null assertions (!) — handle undefined explicitly
+- No commented-out code — delete it or open an issue
+- No TODO without an issue reference
+
+## Security
+
+- Never log secrets, tokens, or passwords
+- Never eval() user input
+- Never trust user-provided paths without sanitization
+
+## Cursor Specific
+
+- Follow the project's existing code style — don't reformat arbitrarily
+- Check existing tests before adding new ones — avoid duplication
+- Prefer editing existing files over creating new ones
+"
+`;

--- a/tests/generators/__snapshots__/claude-settings.test.ts.snap
+++ b/tests/generators/__snapshots__/claude-settings.test.ts.snap
@@ -1,6 +1,6 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`claudeSettingsGenerator output matches snapshot 1`] = `
+exports[`claudeSettingsGenerator generate output matches snapshot 1`] = `
 "{
   "permissions": {
     "deny": [

--- a/tests/generators/__snapshots__/codespell.test.ts.snap
+++ b/tests/generators/__snapshots__/codespell.test.ts.snap
@@ -1,0 +1,9 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`codespellGenerator generate output matches snapshot 1`] = `
+"# ai-guardrails:sha256=2915fe9039a8c2e365b3fdf2c4159cccf4957cfe329602df3680c4cfeb84a2d8
+[codespell]
+skip = .git,*.lock,*.baseline,node_modules,.venv,venv,dist,build,*/tests/fixtures/*
+quiet-level = 2
+"
+`;

--- a/tests/generators/__snapshots__/editorconfig.test.ts.snap
+++ b/tests/generators/__snapshots__/editorconfig.test.ts.snap
@@ -1,0 +1,49 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`editorconfigGenerator generate output matches snapshot with default config 1`] = `
+"# ai-guardrails:sha256=285e2b9659f1911260d0071a2c812420eb87a0cbc1b44cd1c58bc37e6d88b5e1
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 88
+
+[*.{ts,js,tsx,jsx,json,yaml,yml,toml,md}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.go]
+indent_style = tab
+"
+`;
+
+exports[`editorconfigGenerator generate output matches snapshot with indent_width 4 1`] = `
+"# ai-guardrails:sha256=285e2b9659f1911260d0071a2c812420eb87a0cbc1b44cd1c58bc37e6d88b5e1
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 88
+
+[*.{ts,js,tsx,jsx,json,yaml,yml,toml,md}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.go]
+indent_style = tab
+"
+`;

--- a/tests/generators/__snapshots__/lefthook.test.ts.snap
+++ b/tests/generators/__snapshots__/lefthook.test.ts.snap
@@ -1,6 +1,159 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`generateLefthookConfig output matches snapshot for python + typescript 1`] = `
+exports[`generateLefthookConfig output matches snapshot with no active plugins 1`] = `
+"# ai-guardrails:sha256=5972c2b1018a0004966903c703c80ce6ecba537cfdc1652bfbf63aa9f5b9c685
+pre-commit:
+  commands:
+
+    gitleaks:
+      run: gitleaks protect --staged --no-banner
+      fail_text: "Potential secrets detected"
+      priority: 2
+
+    codespell:
+      glob: "*.{ts,md,txt,yaml,yml,toml,json,py,go,rs}"
+      exclude: 'tests/fixtures/.*'
+      run: codespell --check-filenames {staged_files}
+      fail_text: "Spell errors found"
+      priority: 2
+
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}
+      fail_text: "Markdown lint errors found"
+      priority: 2
+
+    check-suppress-comments:
+      glob: "*.{py,ts,tsx,js,jsx,rs,go,cs,lua,sh,bash,zsh,ksh,c,cpp,cc,h,hpp}"
+      run: ai-guardrails hook suppress-comments {staged_files}
+      fail_text: "Inline suppression comments require a reason"
+      priority: 2
+
+    no-commits-to-main:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+        if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+          echo "Direct commits to main are not allowed"
+          exit 1
+        fi
+      fail_text: "Do not commit directly to main"
+      priority: 2
+
+commit-msg:
+  commands:
+    conventional:
+      run: grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?:" {1}
+      fail_text: "Commit message must follow Conventional Commits format"
+"
+`;
+
+exports[`generateLefthookConfig output matches snapshot with TypeScript plugin 1`] = `
+"# ai-guardrails:sha256=5e80cb9e5816489f5709b958b11e480e5e5255f3195ede89a81efefba6f5ef30
+pre-commit:
+  commands:
+
+    biome-fix:
+      glob: "*.{ts,tsx,js,jsx}"
+      run: biome check --write {staged_files} && git add {staged_files}
+      stage_fixed: true
+      priority: 1
+
+    gitleaks:
+      run: gitleaks protect --staged --no-banner
+      fail_text: "Potential secrets detected"
+      priority: 2
+
+    codespell:
+      glob: "*.{ts,md,txt,yaml,yml,toml,json,py,go,rs}"
+      exclude: 'tests/fixtures/.*'
+      run: codespell --check-filenames {staged_files}
+      fail_text: "Spell errors found"
+      priority: 2
+
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}
+      fail_text: "Markdown lint errors found"
+      priority: 2
+
+    check-suppress-comments:
+      glob: "*.{py,ts,tsx,js,jsx,rs,go,cs,lua,sh,bash,zsh,ksh,c,cpp,cc,h,hpp}"
+      run: ai-guardrails hook suppress-comments {staged_files}
+      fail_text: "Inline suppression comments require a reason"
+      priority: 2
+
+    no-commits-to-main:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+        if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+          echo "Direct commits to main are not allowed"
+          exit 1
+        fi
+      fail_text: "Do not commit directly to main"
+      priority: 2
+
+commit-msg:
+  commands:
+    conventional:
+      run: grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?:" {1}
+      fail_text: "Commit message must follow Conventional Commits format"
+"
+`;
+
+exports[`generateLefthookConfig output matches snapshot with Python plugin 1`] = `
+"# ai-guardrails:sha256=6038748e201ff44b36cc96a916909598db6a493793f418ddedd51a8e38dbe3fa
+pre-commit:
+  commands:
+
+    ruff-fix:
+      glob: "*.py"
+      run: ruff check --fix {staged_files} && git add {staged_files}
+      stage_fixed: true
+      priority: 1
+
+    gitleaks:
+      run: gitleaks protect --staged --no-banner
+      fail_text: "Potential secrets detected"
+      priority: 2
+
+    codespell:
+      glob: "*.{ts,md,txt,yaml,yml,toml,json,py,go,rs}"
+      exclude: 'tests/fixtures/.*'
+      run: codespell --check-filenames {staged_files}
+      fail_text: "Spell errors found"
+      priority: 2
+
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}
+      fail_text: "Markdown lint errors found"
+      priority: 2
+
+    check-suppress-comments:
+      glob: "*.{py,ts,tsx,js,jsx,rs,go,cs,lua,sh,bash,zsh,ksh,c,cpp,cc,h,hpp}"
+      run: ai-guardrails hook suppress-comments {staged_files}
+      fail_text: "Inline suppression comments require a reason"
+      priority: 2
+
+    no-commits-to-main:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+        if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+          echo "Direct commits to main are not allowed"
+          exit 1
+        fi
+      fail_text: "Do not commit directly to main"
+      priority: 2
+
+commit-msg:
+  commands:
+    conventional:
+      run: grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?:" {1}
+      fail_text: "Commit message must follow Conventional Commits format"
+"
+`;
+
+exports[`generateLefthookConfig output matches snapshot with TypeScript and Python plugins 1`] = `
 "# ai-guardrails:sha256=b6c8ade2fd39f455819a397861fa96e32076329002bc0438c1e582cf56e2a534
 pre-commit:
   commands:
@@ -59,8 +212,8 @@ commit-msg:
 "
 `;
 
-exports[`generateLefthookConfig output matches snapshot for empty plugins 1`] = `
-"# ai-guardrails:sha256=5972c2b1018a0004966903c703c80ce6ecba537cfdc1652bfbf63aa9f5b9c685
+exports[`generateLefthookConfig output matches snapshot with ignorePaths 1`] = `
+"# ai-guardrails:sha256=62485b889b3195a00697c871c773baddaff7ac8bd00c059364b355e9b7684e5b
 pre-commit:
   commands:
 
@@ -71,19 +224,21 @@ pre-commit:
 
     codespell:
       glob: "*.{ts,md,txt,yaml,yml,toml,json,py,go,rs}"
-      exclude: 'tests/fixtures/.*'
+      exclude: 'tests/fixtures/.*|(vendor/.[^/]*|dist/.[^/]*)'
       run: codespell --check-filenames {staged_files}
       fail_text: "Spell errors found"
       priority: 2
 
     markdownlint:
       glob: "*.md"
+      exclude: '(vendor/.[^/]*|dist/.[^/]*)'
       run: markdownlint-cli2 {staged_files}
       fail_text: "Markdown lint errors found"
       priority: 2
 
     check-suppress-comments:
       glob: "*.{py,ts,tsx,js,jsx,rs,go,cs,lua,sh,bash,zsh,ksh,c,cpp,cc,h,hpp}"
+      exclude: '(vendor/.[^/]*|dist/.[^/]*)'
       run: ai-guardrails hook suppress-comments {staged_files}
       fail_text: "Inline suppression comments require a reason"
       priority: 2

--- a/tests/generators/__snapshots__/markdownlint.test.ts.snap
+++ b/tests/generators/__snapshots__/markdownlint.test.ts.snap
@@ -1,0 +1,14 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`markdownlintGenerator generate output matches snapshot 1`] = `
+"// ai-guardrails:sha256=a15eb63c05e78ca9311f807cff9944c84004a5eca13b49fcaff5d557005f6655
+{
+  "default": true,
+  "MD013": { "line_length": 120, "tables": false, "code_blocks": false },
+  "MD033": false,
+  "MD040": false,
+  "MD041": false,
+  "MD060": false
+}
+"
+`;

--- a/tests/generators/agent-rules.test.ts
+++ b/tests/generators/agent-rules.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildResolvedConfig,
+  MachineConfigSchema,
+  ProjectConfigSchema,
+} from "@/config/schema";
+import { agentRulesGenerator, buildAgentRules } from "@/generators/agent-rules";
+
+function makeConfig() {
+  return buildResolvedConfig(
+    MachineConfigSchema.parse({}),
+    ProjectConfigSchema.parse({})
+  );
+}
+
+describe("agentRulesGenerator", () => {
+  test("has correct id", () => {
+    expect(agentRulesGenerator.id).toBe("agent-rules");
+  });
+
+  test("has correct configFile", () => {
+    expect(agentRulesGenerator.configFile).toBe(".ai-guardrails/agent-rules/base.md");
+  });
+
+  test("generate returns non-empty string", () => {
+    const output = agentRulesGenerator.generate(makeConfig());
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test("generate output contains core principles heading", () => {
+    const output = agentRulesGenerator.generate(makeConfig());
+    expect(output).toContain("## Core Principles");
+  });
+
+  test("generate output contains git workflow section", () => {
+    const output = agentRulesGenerator.generate(makeConfig());
+    expect(output).toContain("## Git Workflow");
+  });
+
+  test("generate output contains security section", () => {
+    const output = agentRulesGenerator.generate(makeConfig());
+    expect(output).toContain("## Security");
+  });
+
+  test("generate output matches snapshot", () => {
+    const output = agentRulesGenerator.generate(makeConfig());
+    expect(output).toMatchSnapshot();
+  });
+});
+
+describe("buildAgentRules", () => {
+  test("claude variant contains Claude Code specific section", () => {
+    const output = buildAgentRules("claude");
+    expect(output).toContain("## Claude Code Specific");
+  });
+
+  test("cursor variant contains Cursor specific section", () => {
+    const output = buildAgentRules("cursor");
+    expect(output).toContain("## Cursor Specific");
+  });
+
+  test("windsurf variant contains Windsurf specific section", () => {
+    const output = buildAgentRules("windsurf");
+    expect(output).toContain("## Windsurf Specific");
+  });
+
+  test("copilot variant contains GitHub Copilot specific section", () => {
+    const output = buildAgentRules("copilot");
+    expect(output).toContain("## GitHub Copilot Specific");
+  });
+
+  test("cline variant contains Cline specific section", () => {
+    const output = buildAgentRules("cline");
+    expect(output).toContain("## Cline Specific");
+  });
+
+  test("aider variant contains Aider specific section", () => {
+    const output = buildAgentRules("aider");
+    expect(output).toContain("## Aider Specific");
+  });
+
+  test("all variants contain base rules", () => {
+    for (const tool of [
+      "claude",
+      "cursor",
+      "windsurf",
+      "copilot",
+      "cline",
+      "aider",
+    ] as const) {
+      const output = buildAgentRules(tool);
+      expect(output).toContain("## Core Principles");
+    }
+  });
+
+  test("buildAgentRules claude matches snapshot", () => {
+    expect(buildAgentRules("claude")).toMatchSnapshot();
+  });
+
+  test("buildAgentRules cursor matches snapshot", () => {
+    expect(buildAgentRules("cursor")).toMatchSnapshot();
+  });
+});

--- a/tests/generators/claude-settings.test.ts
+++ b/tests/generators/claude-settings.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildResolvedConfig,
+  MachineConfigSchema,
+  ProjectConfigSchema,
+} from "@/config/schema";
+import { claudeSettingsGenerator } from "@/generators/claude-settings";
+
+function makeConfig() {
+  return buildResolvedConfig(
+    MachineConfigSchema.parse({}),
+    ProjectConfigSchema.parse({})
+  );
+}
+
+describe("claudeSettingsGenerator", () => {
+  test("has correct id", () => {
+    expect(claudeSettingsGenerator.id).toBe("claude-settings");
+  });
+
+  test("has correct configFile", () => {
+    expect(claudeSettingsGenerator.configFile).toBe(".claude/settings.json");
+  });
+
+  test("generate returns non-empty string", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test("generate output is valid JSON", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  test("generate output contains permissions.deny array", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    const parsed = JSON.parse(output) as { permissions?: { deny?: unknown } };
+    expect(Array.isArray(parsed.permissions?.deny)).toBe(true);
+  });
+
+  test("generate output contains PreToolUse hooks", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    const parsed = JSON.parse(output) as {
+      hooks?: { PreToolUse?: unknown[] };
+    };
+    expect(Array.isArray(parsed.hooks?.PreToolUse)).toBe(true);
+    const hooks = parsed.hooks?.PreToolUse ?? [];
+    expect(hooks.length).toBeGreaterThan(0);
+  });
+
+  test("generate output has Bash PreToolUse hook", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    const parsed = JSON.parse(output) as {
+      hooks?: { PreToolUse?: Array<{ matcher: string }> };
+    };
+    const hooks = parsed.hooks?.PreToolUse ?? [];
+    const bashHook = hooks.find((h) => h.matcher === "Bash");
+    expect(bashHook).toBeDefined();
+  });
+
+  test("generate output has Edit|Write|NotebookEdit PreToolUse hook", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    const parsed = JSON.parse(output) as {
+      hooks?: { PreToolUse?: Array<{ matcher: string }> };
+    };
+    const hooks = parsed.hooks?.PreToolUse ?? [];
+    const editHook = hooks.find((h) => h.matcher === "Edit|Write|NotebookEdit");
+    expect(editHook).toBeDefined();
+  });
+
+  test("generate output matches snapshot", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/tests/generators/codespell.test.ts
+++ b/tests/generators/codespell.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildResolvedConfig,
+  MachineConfigSchema,
+  ProjectConfigSchema,
+} from "@/config/schema";
+import { codespellGenerator } from "@/generators/codespell";
+
+function makeConfig() {
+  return buildResolvedConfig(
+    MachineConfigSchema.parse({}),
+    ProjectConfigSchema.parse({})
+  );
+}
+
+describe("codespellGenerator", () => {
+  test("has correct id", () => {
+    expect(codespellGenerator.id).toBe("codespell");
+  });
+
+  test("has correct configFile", () => {
+    expect(codespellGenerator.configFile).toBe(".codespellrc");
+  });
+
+  test("generate returns non-empty string", () => {
+    const output = codespellGenerator.generate(makeConfig());
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test("generate output matches snapshot", () => {
+    const output = codespellGenerator.generate(makeConfig());
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/tests/generators/editorconfig.test.ts
+++ b/tests/generators/editorconfig.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildResolvedConfig,
+  MachineConfigSchema,
+  ProjectConfigSchema,
+} from "@/config/schema";
+import { editorconfigGenerator } from "@/generators/editorconfig";
+
+function makeConfig(indentWidth?: number) {
+  return buildResolvedConfig(
+    MachineConfigSchema.parse({}),
+    ProjectConfigSchema.parse(
+      indentWidth !== undefined ? { config: { indent_width: indentWidth } } : {}
+    )
+  );
+}
+
+describe("editorconfigGenerator", () => {
+  test("has correct id", () => {
+    expect(editorconfigGenerator.id).toBe("editorconfig");
+  });
+
+  test("has correct configFile", () => {
+    expect(editorconfigGenerator.configFile).toBe(".editorconfig");
+  });
+
+  test("generate returns non-empty string", () => {
+    const output = editorconfigGenerator.generate(makeConfig());
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test("generate output matches snapshot with default config", () => {
+    const output = editorconfigGenerator.generate(makeConfig());
+    expect(output).toMatchSnapshot();
+  });
+
+  test("generate output matches snapshot with indent_width 4", () => {
+    const output = editorconfigGenerator.generate(makeConfig(4));
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/tests/generators/lefthook.test.ts
+++ b/tests/generators/lefthook.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildResolvedConfig,
+  MachineConfigSchema,
+  ProjectConfigSchema,
+} from "@/config/schema";
+import {
+  generateLefthookConfig,
+  LEFTHOOK_GENERATOR_ID,
+  lefthookGenerator,
+} from "@/generators/lefthook";
+import { makePlugin } from "../fakes/fake-language-plugin";
+
+function makeConfig(ignorePaths?: string[]) {
+  return buildResolvedConfig(
+    MachineConfigSchema.parse({}),
+    ProjectConfigSchema.parse(
+      ignorePaths !== undefined && ignorePaths.length > 0
+        ? { ignore_paths: ignorePaths }
+        : {}
+    )
+  );
+}
+
+describe("lefthookGenerator", () => {
+  test("has correct id", () => {
+    expect(lefthookGenerator.id).toBe(LEFTHOOK_GENERATOR_ID);
+    expect(lefthookGenerator.id).toBe("lefthook");
+  });
+
+  test("has correct configFile", () => {
+    expect(lefthookGenerator.configFile).toBe("lefthook.yml");
+  });
+
+  test("generate() throws — direct call not supported", () => {
+    expect(() => lefthookGenerator.generate(makeConfig())).toThrow(
+      "lefthookGenerator.generate() must not be called directly"
+    );
+  });
+});
+
+describe("generateLefthookConfig", () => {
+  test("returns non-empty string", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test("output contains pre-commit section", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).toContain("pre-commit:");
+  });
+
+  test("output contains commit-msg section", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).toContain("commit-msg:");
+  });
+
+  test("output contains gitleaks command", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).toContain("gitleaks:");
+  });
+
+  test("output contains codespell command", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).toContain("codespell:");
+  });
+
+  test("output contains markdownlint command", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).toContain("markdownlint:");
+  });
+
+  test("includes biome-fix when TypeScript plugin active", () => {
+    const output = generateLefthookConfig(makeConfig(), [makePlugin("typescript")]);
+    expect(output).toContain("biome-fix:");
+  });
+
+  test("does not include biome-fix when TypeScript plugin absent", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).not.toContain("biome-fix:");
+  });
+
+  test("includes ruff-fix when Python plugin active", () => {
+    const output = generateLefthookConfig(makeConfig(), [makePlugin("python")]);
+    expect(output).toContain("ruff-fix:");
+  });
+
+  test("does not include ruff-fix when Python plugin absent", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).not.toContain("ruff-fix:");
+  });
+
+  test("includes both biome-fix and ruff-fix when TypeScript and Python active", () => {
+    const output = generateLefthookConfig(makeConfig(), [
+      makePlugin("typescript"),
+      makePlugin("python"),
+    ]);
+    expect(output).toContain("biome-fix:");
+    expect(output).toContain("ruff-fix:");
+  });
+
+  test("output matches snapshot with no active plugins", () => {
+    const output = generateLefthookConfig(makeConfig(), []);
+    expect(output).toMatchSnapshot();
+  });
+
+  test("output matches snapshot with TypeScript plugin", () => {
+    const output = generateLefthookConfig(makeConfig(), [makePlugin("typescript")]);
+    expect(output).toMatchSnapshot();
+  });
+
+  test("output matches snapshot with Python plugin", () => {
+    const output = generateLefthookConfig(makeConfig(), [makePlugin("python")]);
+    expect(output).toMatchSnapshot();
+  });
+
+  test("output matches snapshot with TypeScript and Python plugins", () => {
+    const output = generateLefthookConfig(makeConfig(), [
+      makePlugin("typescript"),
+      makePlugin("python"),
+    ]);
+    expect(output).toMatchSnapshot();
+  });
+
+  test("output contains exclude when ignorePaths configured", () => {
+    const output = generateLefthookConfig(makeConfig(["vendor/**"]), []);
+    expect(output).toContain("exclude:");
+  });
+
+  test("output matches snapshot with ignorePaths", () => {
+    const output = generateLefthookConfig(makeConfig(["vendor/**", "dist/**"]), []);
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/tests/generators/markdownlint.test.ts
+++ b/tests/generators/markdownlint.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildResolvedConfig,
+  MachineConfigSchema,
+  ProjectConfigSchema,
+} from "@/config/schema";
+import { markdownlintGenerator } from "@/generators/markdownlint";
+
+function makeConfig() {
+  return buildResolvedConfig(
+    MachineConfigSchema.parse({}),
+    ProjectConfigSchema.parse({})
+  );
+}
+
+describe("markdownlintGenerator", () => {
+  test("has correct id", () => {
+    expect(markdownlintGenerator.id).toBe("markdownlint");
+  });
+
+  test("has correct configFile", () => {
+    expect(markdownlintGenerator.configFile).toBe(".markdownlint.jsonc");
+  });
+
+  test("generate returns non-empty string", () => {
+    const output = markdownlintGenerator.generate(makeConfig());
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test("generate output contains valid JSON body", () => {
+    const output = markdownlintGenerator.generate(makeConfig());
+    // Strip the JSONC hash header comment line(s) to get the JSON body
+    const jsonBody = output
+      .split("\n")
+      .filter((line) => !line.startsWith("//"))
+      .join("\n")
+      .trim();
+    expect(() => JSON.parse(jsonBody)).not.toThrow();
+  });
+
+  test("generate output matches snapshot", () => {
+    const output = markdownlintGenerator.generate(makeConfig());
+    expect(output).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds snapshot tests for all 6 generators that had no dedicated test files: `codespell`, `editorconfig`, `markdownlint`, `agent-rules`, `claude-settings`, `lefthook`
- Each test file covers: correct `id`/`configFile` contracts, non-empty output, content/validity assertions, and snapshot matching
- `lefthook` tests cover language-plugin combinations (TypeScript → biome-fix, Python → ruff-fix, combined, and ignorePaths variants)
- `agent-rules` tests cover all 6 tool variants (`claude`, `cursor`, `windsurf`, `copilot`, `cline`, `aider`) via `buildAgentRules`
- 59 new tests, 13 snapshots created

## Test plan

- [x] `bun test tests/generators/` — 59 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Pre-commit hooks passed (biome, codespell, gitleaks, conventional commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)