### PR TITLE
chore: clean up stale comments, docs, and plan artifacts (#153-157)

### DIFF
--- a/.claude/rules/test-conventions.md
+++ b/.claude/rules/test-conventions.md
@@ -21,10 +21,12 @@
 
 ## Naming
 
-- `test_<function>_<scenario>_<expected>` pattern
+- Descriptive names that read as a sentence — clarity is the requirement, not a rigid format
+- Common patterns: `"returns X when Y"`, `"<function> <scenario> <expected>"`
 - Examples:
-  - `test parseRuffOutput returns empty array for empty stdout`
-  - `test filterIssues removes issues matching isAllowed`
+  - `"parseRuffOutput returns empty array for empty stdout"`
+  - `"filterIssues removes issues matching isAllowed"`
+  - `"returns [] when stdout is empty"`
 
 ## Snapshot Tests
 

--- a/docs/bugs/baseline-fingerprint-gap.md
+++ b/docs/bugs/baseline-fingerprint-gap.md
@@ -1,5 +1,17 @@
 # Bug: Baseline Filtering and Stable Fingerprints Not Wired into Check Pipeline
 
+## RESOLVED (2026-03-19)
+
+All 3 issues fixed:
+
+- Issue 1 (baseline not wired): PR #140
+- Issue 2 (absolute paths): PR #141  
+- Issue 3 (message-based fingerprints): PR #143
+
+Original content preserved below for reference.
+
+---
+
 **Discovered:** Round 7 full codebase scan (PR #95, 2026-03-08)
 **Severity:** Critical — the core "hold-the-line" feature of `ai-guardrails check` is non-functional
 **Status:** Deferred — models and utilities exist, integration is the missing piece

--- a/src/models/lint-issue.ts
+++ b/src/models/lint-issue.ts
@@ -25,9 +25,7 @@ export interface FingerprintOpts {
  * File path is included so identical issues in different files produce distinct fingerprints.
  *
  * NOTE: Callers must pass a project-relative path as `file`, NOT an absolute path.
- * Absolute paths make baselines non-portable between machines (local vs CI at a different
- * checkout root). All runners currently pass absolute paths, so baselines break in CI.
- * See docs/bugs/baseline-fingerprint-gap.md Issue 3 for the fix outline.
+ * Callers pass project-relative paths for portable baselines.
  */
 export function computeFingerprint(opts: FingerprintOpts): string {
   const { rule, file, lineContent, contextBefore, contextAfter } = opts;

--- a/src/utils/fingerprint.ts
+++ b/src/utils/fingerprint.ts
@@ -6,16 +6,6 @@ const CONTEXT_LINES = 2;
 /**
  * Compute a stable fingerprint for a lint issue using surrounding source lines.
  * The fingerprint includes the file path to avoid collisions across files.
- *
- * NOTE: This function is not yet called by any runner. All runners currently
- * call computeFingerprint() directly with the tool's error message as lineContent,
- * which makes fingerprints dependent on tool output wording rather than source
- * code content. This means fingerprints will silently break when tools change
- * their error messages (e.g. version upgrades), invalidating saved baselines.
- *
- * TODO(baseline): Wire this into each runner's run() method by reading source
- * files and grouping issues by file before computing fingerprints.
- * See docs/bugs/baseline-fingerprint-gap.md for the full fix outline.
  */
 export function fingerprintIssue(
   issue: Omit<LintIssue, "fingerprint">,


### PR DESCRIPTION
## Summary

- **#153** — Remove stale NOTE/TODO block from `fingerprintIssue` in `src/utils/fingerprint.ts`; wiring was completed in PR #143
- **#154** — Update stale comment in `src/models/lint-issue.ts`; callers now pass project-relative paths (fixed in PR #141)
- **#155** — Update test naming convention doc to reflect actual practice: descriptive sentence-style names, not a rigid `test_fn_scenario_expected` format
- **#156** — Mark `docs/bugs/baseline-fingerprint-gap.md` as RESOLVED with references to PRs #140, #141, #143
- **#157** — Delete 6 completed plan artifact directories from `docs/plans/`

## Test plan

- [x] `bun test` — 882 pass, 14 pre-existing failures (unrelated integration tests)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] markdownlint — clean (blank lines around list in RESOLVED section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)