### PR TITLE
refactor(runners): replace as casts with in-operator type guards (#151)

### DIFF
--- a/src/runners/biome.ts
+++ b/src/runners/biome.ts
@@ -70,9 +70,9 @@ function extractMessage(message: unknown): string {
     typeof message === "object" &&
     message !== null &&
     "content" in message &&
-    typeof (message as { content: unknown }).content === "string"
+    typeof message.content === "string"
   ) {
-    return (message as { content: string }).content;
+    return message.content;
   }
   return String(message);
 }
@@ -82,7 +82,7 @@ function isRdjsonOutput(value: unknown): value is RdjsonOutput {
     typeof value === "object" &&
     value !== null &&
     "diagnostics" in value &&
-    Array.isArray((value as RdjsonOutput).diagnostics)
+    Array.isArray(value.diagnostics)
   );
 }
 

--- a/src/runners/clippy.ts
+++ b/src/runners/clippy.ts
@@ -29,7 +29,7 @@ function isClippyEntry(value: unknown): value is ClippyEntry {
     typeof value === "object" &&
     value !== null &&
     "reason" in value &&
-    typeof (value as Record<string, unknown>).reason === "string"
+    typeof value.reason === "string"
   );
 }
 

--- a/src/runners/pyright.ts
+++ b/src/runners/pyright.ts
@@ -24,31 +24,35 @@ interface PyrightOutput {
 
 function isPyrightRange(value: unknown): value is PyrightRange {
   if (typeof value !== "object" || value === null) return false;
-  const v = value as { start: unknown };
-  const start = v.start;
+  if (!("start" in value)) return false;
+  const start = value.start;
   return (
     typeof start === "object" &&
     start !== null &&
-    typeof (start as { line: unknown; character: unknown }).line === "number" &&
-    typeof (start as { line: unknown; character: unknown }).character === "number"
+    "line" in start &&
+    typeof start.line === "number" &&
+    "character" in start &&
+    typeof start.character === "number"
   );
 }
 
 function isPyrightDiagnostic(value: unknown): value is PyrightDiagnostic {
   if (typeof value !== "object" || value === null) return false;
-  const v = value as PyrightDiagnostic & { range: unknown };
   return (
-    typeof v.file === "string" &&
-    typeof v.severity === "string" &&
-    typeof v.message === "string" &&
-    isPyrightRange(v.range)
+    "file" in value &&
+    typeof value.file === "string" &&
+    "severity" in value &&
+    typeof value.severity === "string" &&
+    "message" in value &&
+    typeof value.message === "string" &&
+    "range" in value &&
+    isPyrightRange(value.range)
   );
 }
 
 function isPyrightOutput(value: unknown): value is PyrightOutput {
   if (typeof value !== "object" || value === null) return false;
-  const v = value as { generalDiagnostics: unknown };
-  return Array.isArray(v.generalDiagnostics);
+  return "generalDiagnostics" in value && Array.isArray(value.generalDiagnostics);
 }
 
 /**

--- a/src/runners/ruff.ts
+++ b/src/runners/ruff.ts
@@ -23,15 +23,25 @@ interface RuffItem {
 
 function isRuffItem(value: unknown): value is RuffItem {
   if (typeof value !== "object" || value === null) return false;
-  const v = value as RuffItem & { location: unknown };
+  if (
+    !("code" in value) ||
+    typeof value.code !== "string" ||
+    !("filename" in value) ||
+    typeof value.filename !== "string" ||
+    !("message" in value) ||
+    typeof value.message !== "string"
+  ) {
+    return false;
+  }
+  if (!("location" in value)) return false;
+  const loc = value.location;
   return (
-    typeof v.code === "string" &&
-    typeof v.filename === "string" &&
-    typeof v.location === "object" &&
-    v.location !== null &&
-    typeof (v.location as { row: unknown; column: unknown }).row === "number" &&
-    typeof (v.location as { row: unknown; column: unknown }).column === "number" &&
-    typeof v.message === "string"
+    typeof loc === "object" &&
+    loc !== null &&
+    "row" in loc &&
+    typeof loc.row === "number" &&
+    "column" in loc &&
+    typeof loc.column === "number"
   );
 }
 

--- a/src/runners/shellcheck.ts
+++ b/src/runners/shellcheck.ts
@@ -26,7 +26,7 @@ function isShellcheckOutput(value: unknown): value is ShellcheckOutput {
     typeof value === "object" &&
     value !== null &&
     "comments" in value &&
-    Array.isArray((value as ShellcheckOutput).comments)
+    Array.isArray(value.comments)
   );
 }
 

--- a/src/steps/check-step.ts
+++ b/src/steps/check-step.ts
@@ -39,7 +39,8 @@ export async function checkStep(
               `  ${runner.name} not found — skipping (${runner.installHint.description})`
             );
             skipped++;
-            return [] as LintIssue[];
+            const empty: LintIssue[] = [];
+            return empty;
           }
           return runner.run(opts);
         })

--- a/src/steps/run-linters.ts
+++ b/src/steps/run-linters.ts
@@ -20,7 +20,10 @@ export async function runLinterCollection(
     languages.flatMap((plugin) =>
       plugin.runners().map(async (runner) => {
         const available = await runner.isAvailable(commandRunner, projectDir);
-        if (!available) return [] as LintIssue[];
+        if (!available) {
+          const empty: LintIssue[] = [];
+          return empty;
+        }
         return runner.run(opts);
       })
     )


### PR DESCRIPTION
## Summary

- Replace all 15 `as` type casts across 7 runner/step files with proper `in` operator + `typeof` narrowing
- After `"key" in obj`, TypeScript narrows `obj` to know `key` exists (as `unknown`), eliminating the need for casts to access the property
- Files changed: `biome.ts` (3 casts), `pyright.ts` (5 casts), `ruff.ts` (3 casts), `clippy.ts` (1 cast), `shellcheck.ts` (1 cast), `run-linters.ts` (1 cast), `check-step.ts` (1 cast)
- The two `[] as LintIssue[]` casts in steps are replaced with `const empty: LintIssue[] = []; return empty;`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (186 files, no fixes applied)
- [x] `bun test` — 882 pass, 14 fail (same 14 pre-existing integration failures requiring built binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)