### PR TITLE
fix: regenerate .claude/settings.json with TS binary hooks (#150)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,69 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(rm -fr *)",
+      "Bash(sudo rm -rf *)",
+      "Bash(sudo rm -fr *)",
+      "Bash(git push --force)",
+      "Bash(git push --force *)",
+      "Bash(git push -f)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard*)",
+      "Bash(git checkout -- *)",
+      "Bash(git restore -- *)",
+      "Bash(git clean -f*)",
+      "Bash(git clean --force*)",
+      "Bash(git branch -D *)",
+      "Bash(git branch --delete --force *)",
+      "Bash(git commit --no-verify*)",
+      "Bash(git commit -n *)",
+      "Bash(git commit -n)",
+      "Bash(chmod -R 777*)",
+      "Bash(chmod -R a+rwx*)",
+      "Bash(curl * | bash)",
+      "Bash(curl * | sh)",
+      "Bash(curl * | zsh)",
+      "Bash(curl * | dash)",
+      "Bash(curl * | ksh)",
+      "Bash(wget * | bash)",
+      "Bash(wget * | sh)",
+      "Bash(wget * | zsh)",
+      "Bash(wget * | dash)",
+      "Bash(wget * | ksh)",
+      "Bash(eval $(*))",
+      "Bash(python -c*import os*system*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ ! -f ./dist/ai-guardrails ] && exit 0; ./dist/ai-guardrails hook dangerous-cmd"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ ! -f ./dist/ai-guardrails ] && exit 0; ./dist/ai-guardrails hook protect-configs"
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ ! -f ./dist/ai-guardrails ] && exit 0; ./dist/ai-guardrails hook protect-reads"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ Thumbs.db
 .ai-guardrails/lib/
 .claude/*
 !.claude/rules/
+!.claude/settings.json
 .coverage
 .playwright-mcp/


### PR DESCRIPTION
## Summary

- Replaces stale Python `uv run python -m ai_guardrails.hooks.*` commands with TS binary hooks using existence guard `[ ! -f ./dist/ai-guardrails ] && exit 0`
- Updates hooks: `Bash` → `dangerous-cmd`, `Edit|Write|NotebookEdit` → `protect-configs`, `Read` → `protect-reads`
- Updates `deny` globs to match current rule groups (pure `Bash(...)` patterns from all 6 rule groups; removes stale Edit/Write file-path patterns)
- Adds `.gitignore` exception so `.claude/settings.json` is tracked alongside `.claude/rules/`

## Test plan

- [x] `bun test` — 896 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Content verified against `tests/generators/__snapshots__/claude-settings.test.ts.snap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)