### PR TITLE
refactor: abstract process.stdin behind PipelineContext (#152)

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -1,3 +1,4 @@
+import { createInterface } from "node:readline";
 import {
   buildResolvedConfig,
   MachineConfigSchema,
@@ -23,5 +24,8 @@ export function buildContext(
     commandRunner: new RealCommandRunner(),
     console: new RealConsole(),
     flags,
+    isTTY: process.stdin.isTTY === true,
+    createReadline: () =>
+      createInterface({ input: process.stdin, output: process.stdout }),
   };
 }

--- a/src/pipelines/init.ts
+++ b/src/pipelines/init.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from "node:path";
-import { createInterface } from "node:readline";
+import type { Interface as ReadlineInterface } from "node:readline";
 import { stringify as stringifyToml } from "smol-toml";
 import { PROFILES, type Profile } from "@/config/schema";
 import type { Console } from "@/infra/console";
@@ -15,21 +15,16 @@ function isProfile(value: string): value is Profile {
   return (PROFILES as readonly string[]).includes(value);
 }
 
-function createStdinReader(): ReturnType<typeof createInterface> {
-  return createInterface({ input: process.stdin, output: process.stdout });
-}
-
-async function askQuestion(
-  rl: ReturnType<typeof createInterface>,
-  question: string
-): Promise<string> {
+async function askQuestion(rl: ReadlineInterface, question: string): Promise<string> {
   return new Promise((resolve) => {
     rl.question(question, resolve);
   });
 }
 
-async function promptProfile(): Promise<Profile> {
-  const rl = createStdinReader();
+async function promptProfile(
+  createReadline: () => ReadlineInterface
+): Promise<Profile> {
+  const rl = createReadline();
   try {
     let prompt = "Select profile [strict/standard/minimal] (default: standard): ";
     for (;;) {
@@ -44,8 +39,10 @@ async function promptProfile(): Promise<Profile> {
   }
 }
 
-async function promptIgnoreRules(): Promise<string[]> {
-  const rl = createStdinReader();
+async function promptIgnoreRules(
+  createReadline: () => ReadlineInterface
+): Promise<string[]> {
+  const rl = createReadline();
   try {
     const input = await askQuestion(
       rl,
@@ -102,7 +99,14 @@ function logInitStart(cons: Console, interactive: boolean): void {
 
 export const initPipeline: Pipeline = {
   async run(ctx: PipelineContext): Promise<PipelineResult> {
-    const { projectDir, fileManager, commandRunner, console: cons } = ctx;
+    const {
+      projectDir,
+      fileManager,
+      commandRunner,
+      console: cons,
+      isTTY,
+      createReadline,
+    } = ctx;
 
     const force = ctx.flags.force === true;
     const upgrade = ctx.flags.upgrade === true;
@@ -116,16 +120,15 @@ export const initPipeline: Pipeline = {
       };
     }
 
-    const isInteractive =
-      process.stdin.isTTY === true || ctx.flags.interactive === true;
+    const isInteractive = isTTY || ctx.flags.interactive === true;
     logInitStart(cons, isInteractive);
 
     let profile: Profile = "standard";
     let ignoreRules: string[] = [];
 
     if (isInteractive) {
-      profile = await promptProfile();
-      ignoreRules = await promptIgnoreRules();
+      profile = await promptProfile(createReadline);
+      ignoreRules = await promptIgnoreRules(createReadline);
     } else {
       const flagProfile = ctx.flags.profile;
       if (typeof flagProfile === "string" && isProfile(flagProfile)) {
@@ -150,7 +153,14 @@ export const initPipeline: Pipeline = {
     cons.step("Checking prerequisites...");
     const { report } = await checkPrerequisites(cons, commandRunner, languages);
 
-    await installPrerequisites(cons, commandRunner, report, projectDir, isInteractive);
+    await installPrerequisites(
+      cons,
+      commandRunner,
+      report,
+      projectDir,
+      isInteractive,
+      createReadline
+    );
 
     return installPipeline.run(ctx);
   },

--- a/src/pipelines/types.ts
+++ b/src/pipelines/types.ts
@@ -1,3 +1,4 @@
+import type { Interface as ReadlineInterface } from "node:readline";
 import type { ResolvedConfig } from "@/config/schema";
 import type { CommandRunner } from "@/infra/command-runner";
 import type { Console } from "@/infra/console";
@@ -10,6 +11,8 @@ export interface PipelineContext {
   commandRunner: CommandRunner;
   console: Console;
   flags: Record<string, unknown>;
+  isTTY: boolean;
+  createReadline: () => ReadlineInterface;
 }
 
 export interface PipelineResult {

--- a/src/steps/install-prerequisites.ts
+++ b/src/steps/install-prerequisites.ts
@@ -1,4 +1,4 @@
-import { createInterface } from "node:readline";
+import type { Interface as ReadlineInterface } from "node:readline";
 
 import type { CommandRunner } from "@/infra/command-runner";
 import type { Console } from "@/infra/console";
@@ -58,7 +58,8 @@ export async function installPrerequisites(
   commandRunner: CommandRunner,
   report: PrereqReport,
   projectDir: string,
-  interactive = false
+  isTTY: boolean,
+  createReadline: () => ReadlineInterface
 ): Promise<StepResult> {
   if (report.missing.length === 0) {
     return ok("No missing prerequisites");
@@ -66,14 +67,12 @@ export async function installPrerequisites(
 
   printMissingTools(cons, report.missing);
 
-  const isTTY = process.stdin.isTTY === true || interactive;
-
   if (!isTTY) {
     cons.warning("\nRun the commands above, then re-run `ai-guardrails init`.");
     return ok("Missing tools listed — install manually and re-run init");
   }
 
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const rl = createReadline();
   let input: string;
   try {
     const answer = await new Promise<string>((resolve) => {

--- a/tests/steps/install-prerequisites.test.ts
+++ b/tests/steps/install-prerequisites.test.ts
@@ -4,6 +4,7 @@ import type { PrereqReport } from "@/steps/check-prerequisites";
 import { installPrerequisites } from "@/steps/install-prerequisites";
 import { FakeCommandRunner } from "../fakes/fake-command-runner";
 import { FakeConsole } from "../fakes/fake-console";
+import { noopReadline } from "./pipeline-shared";
 
 function makeReport(missing: Array<{ id: string; hint: InstallHint }>): PrereqReport {
   return {
@@ -13,14 +14,21 @@ function makeReport(missing: Array<{ id: string; hint: InstallHint }>): PrereqRe
 }
 
 describe("installPrerequisites (non-TTY)", () => {
-  // All tests run in non-TTY (CI) context so the interactive branch is not exercised.
+  // All tests run with isTTY=false so the interactive branch is not exercised.
 
   test("returns ok immediately when no tools are missing", async () => {
     const cr = new FakeCommandRunner();
     const cons = new FakeConsole();
     const report: PrereqReport = { missing: [], available: ["ruff"] };
 
-    const result = await installPrerequisites(cons, cr, report, "/project");
+    const result = await installPrerequisites(
+      cons,
+      cr,
+      report,
+      "/project",
+      false,
+      noopReadline
+    );
 
     expect(result.status).toBe("ok");
     expect(cr.calls).toHaveLength(0);
@@ -36,8 +44,14 @@ describe("installPrerequisites (non-TTY)", () => {
       },
     ]);
 
-    // Ensure non-TTY path is taken (process.stdin.isTTY is undefined in test env)
-    const result = await installPrerequisites(cons, cr, report, "/project");
+    const result = await installPrerequisites(
+      cons,
+      cr,
+      report,
+      "/project",
+      false,
+      noopReadline
+    );
 
     expect(result.status).toBe("ok");
     // Should have warned about the missing tool and printed the hint
@@ -62,7 +76,7 @@ describe("installPrerequisites (non-TTY)", () => {
       },
     ]);
 
-    await installPrerequisites(cons, cr, report, "/project");
+    await installPrerequisites(cons, cr, report, "/project", false, noopReadline);
 
     const allWarnings = cons.warnings.join("\n");
     expect(allWarnings).toContain("npm install -D pyright");
@@ -75,7 +89,14 @@ describe("installPrerequisites (non-TTY)", () => {
       { id: "unknown-tool", hint: { description: "Some obscure tool" } },
     ]);
 
-    const result = await installPrerequisites(cons, cr, report, "/project");
+    const result = await installPrerequisites(
+      cons,
+      cr,
+      report,
+      "/project",
+      false,
+      noopReadline
+    );
 
     expect(result.status).toBe("ok");
   });

--- a/tests/steps/pipeline-shared.ts
+++ b/tests/steps/pipeline-shared.ts
@@ -1,3 +1,4 @@
+import type { Interface as ReadlineInterface } from "node:readline";
 import type { World } from "@questi0nm4rk/feats";
 import {
   buildResolvedConfig,
@@ -22,6 +23,11 @@ function freshConfig() {
   );
 }
 
+/** Readline factory that throws if called — use in non-TTY test contexts. */
+export function noopReadline(): ReadlineInterface {
+  throw new Error("createReadline called in a non-TTY test context");
+}
+
 export function makeBaseCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
   const fm = new FakeFileManager();
   fm.seed("/project/pyproject.toml", "[tool.ruff]");
@@ -33,6 +39,8 @@ export function makeBaseCtx(overrides: Partial<PipelineContext> = {}): PipelineC
     commandRunner: new FakeCommandRunner(),
     console: new FakeConsole(),
     flags: {},
+    isTTY: false,
+    createReadline: noopReadline,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Adds `isTTY: boolean` and `createReadline: () => ReadlineInterface` to `PipelineContext`
- `src/commands/context.ts` provides the real implementations (only place that may reference `process.stdin`)
- `src/steps/install-prerequisites.ts` and `src/pipelines/init.ts` now receive these through the context — zero direct `process.stdin`/`process.stdout` access
- Tests updated: `makeBaseCtx` in `pipeline-shared.ts` defaults to `isTTY: false` and a `noopReadline` that throws if called; `install-prerequisites.test.ts` passes explicit params

## Test plan

- [x] `bun test` — 882 unit tests pass (14 e2e failures are pre-existing: no `dist/ai-guardrails` in worktree)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `grep -rn 'process\.stdin\|process\.stdout' src/steps/ src/pipelines/` — 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)