### PR TITLE
feat(ci): add release workflow for tag-based binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # full history needed for changelog generation
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.10"
 
@@ -61,7 +61,6 @@ jobs:
           fi
           # Write to file for gh release
           echo "$CHANGES" > /tmp/changelog.md
-          echo "changelog_file=/tmp/changelog.md" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*` tag push
- Pipeline: checkout (full history) → install → test → build → SHA-256 → changelog → `gh release create`
- Tests act as release gate — no binary produced if tests fail
- Attaches `dist/ai-guardrails` (Linux x64) and `dist/ai-guardrails.sha256` to the GitHub Release
- Changelog generated from `git log` between previous tag and HEAD (falls back to full log on first release)
- Added `fetch-depth: 0` to checkout so `git describe` can find previous tags

## Notes

- Cross-platform builds deferred to phase 4.3
- Release process documented in workflow header comments
- `GITHUB_REF_NAME` used (server-set env var) — no `${{ ... }}` interpolation in `run:` scripts

## Test plan

- [ ] Push a `v*` tag to a fork and verify the workflow triggers
- [ ] Confirm release is created with both binary and `.sha256` attached
- [ ] Confirm changelog lists commits since last tag
- [ ] Confirm tests fail → release is NOT created

🤖 Generated with [Claude Code](https://claude.com/claude-code)