### PR TITLE
feat(cli): read version from package.json instead of hardcoding

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,11 +7,12 @@ import { runInstall } from "@/commands/install";
 import { runReport } from "@/commands/report";
 import { runSnapshot } from "@/commands/snapshot";
 import { runStatus } from "@/commands/status";
+import pkg from "../package.json";
 
 const program = new Command()
   .name("ai-guardrails")
   .description("Pedantic code quality enforcement for AI-maintained repositories")
-  .version("3.0.0");
+  .version(pkg.version);
 
 // ---------------------------------------------------------------------------
 // Global options (inherited by subcommands via .optsWithGlobals())

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

- Remove hardcoded `"3.0.0"` string from `src/cli.ts`
- Add `resolveJsonModule: true` to `tsconfig.json` to enable typed JSON imports
- Import `package.json` directly; `program.version(pkg.version)` now picks up the version automatically on every build

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes (import sorted per Biome's organizeImports)
- [x] `bun test` — 882 pass, 14 pre-existing failures (unchanged)
- [x] `bun run build && ./dist/ai-guardrails --version` — outputs `3.0.0` from package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)