### PR TITLE
feat(ci): cross-platform builds for Linux + macOS (x64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@
 # Release process:
 #   1. npm version <patch|minor|major>   (bumps package.json, commits, creates git tag)
 #   2. git push origin main --tags       (triggers this workflow)
-#
-# Cross-platform builds are deferred to phase 4.3.
-# This workflow produces a Linux x64 binary only.
 
 name: Release
 
@@ -36,14 +33,18 @@ jobs:
       - name: Run tests
         run: bun test
 
-      - name: Build binary
-        run: bun run build
+      - name: Build binaries
+        run: |
+          bun build src/cli.ts --compile --bytecode --production --target=bun-linux-x64 --outfile dist/ai-guardrails-linux-x64
+          bun build src/cli.ts --compile --bytecode --production --target=bun-linux-arm64 --outfile dist/ai-guardrails-linux-arm64
+          bun build src/cli.ts --compile --bytecode --production --target=bun-darwin-x64 --outfile dist/ai-guardrails-darwin-x64
+          bun build src/cli.ts --compile --bytecode --production --target=bun-darwin-arm64 --outfile dist/ai-guardrails-darwin-arm64
 
-      - name: Compute SHA-256 checksum
+      - name: Compute checksums
         run: |
           cd dist
-          sha256sum ai-guardrails > ai-guardrails.sha256
-          cat ai-guardrails.sha256
+          sha256sum ai-guardrails-* > checksums.sha256
+          cat checksums.sha256
 
       - name: Generate changelog
         id: changelog
@@ -67,5 +68,8 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file /tmp/changelog.md \
-            dist/ai-guardrails \
-            dist/ai-guardrails.sha256
+            dist/ai-guardrails-linux-x64 \
+            dist/ai-guardrails-linux-arm64 \
+            dist/ai-guardrails-darwin-x64 \
+            dist/ai-guardrails-darwin-arm64 \
+            dist/checksums.sha256


### PR DESCRIPTION
## Summary

- Replaces single Linux x64 binary build with 4-target cross-compilation (linux-x64, linux-arm64, darwin-x64, darwin-arm64)
- Updates checksum step to compute SHA-256 for all binaries into a single `checksums.sha256` file
- Updates release upload to attach all 4 binaries + the combined checksum file
- Removes the "Cross-platform builds are deferred" comment from the workflow header
- Pinned action SHAs preserved (actions/checkout, oven-sh/setup-bun)
- `package.json` build script unchanged — cross-compilation is CI-only

## Test plan

- [ ] Verify YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] On a tag push, confirm all 4 binaries appear in the GitHub Release assets
- [ ] Confirm `checksums.sha256` is attached and contains 4 entries
- [ ] Verify existing `bun run build` (local dev) still produces `dist/ai-guardrails` for the host platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)