### PR TITLE
fix: remove unnecessary as casts in askChoice

### DIFF
--- a/src/init/prompt.ts
+++ b/src/init/prompt.ts
@@ -58,8 +58,8 @@ export async function askChoice<T extends string>(
       const input = await ask(rl, prompt);
       const trimmed = input.trim().toLowerCase();
       if (trimmed === "") return defaultChoice;
-      const match = (choices as readonly string[]).find((c) => c === trimmed);
-      if (match !== undefined) return match as T;
+      const match = choices.find((c) => c === trimmed);
+      if (match !== undefined) return match;
       prompt = `Invalid. Choose ${hint} (default: ${defaultChoice}): `;
     }
   } finally {


### PR DESCRIPTION
Removes 2 as casts in prompt.ts. Generic constraint T extends string already guarantees types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code efficiency and type handling for choice selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->