### PR TITLE
fix: use command -v for hook binary resolution (#181)

### DIFF
--- a/src/generators/claude-settings.ts
+++ b/src/generators/claude-settings.ts
@@ -29,7 +29,8 @@ function renderClaudeSettings(_config: ResolvedConfig): string {
   // Always emit ALL deny globs regardless of disabled_groups config.
   // settings.json deny patterns are a first-layer static safety net,
   // independent of hook-level config toggling.
-  const guard = "[ ! -f ./dist/ai-guardrails ] && exit 0";
+  const guard = "command -v ai-guardrails >/dev/null 2>&1 || exit 0";
+  const bin = "ai-guardrails";
   const settings: ClaudeSettings = {
     permissions: {
       deny: collectDenyGlobs(ALL_RULE_GROUPS),
@@ -41,7 +42,7 @@ function renderClaudeSettings(_config: ResolvedConfig): string {
           hooks: [
             {
               type: "command",
-              command: `${guard}; ./dist/ai-guardrails hook dangerous-cmd`,
+              command: `${guard}; ${bin} hook dangerous-cmd`,
             },
           ],
         },
@@ -50,7 +51,7 @@ function renderClaudeSettings(_config: ResolvedConfig): string {
           hooks: [
             {
               type: "command",
-              command: `${guard}; ./dist/ai-guardrails hook protect-configs`,
+              command: `${guard}; ${bin} hook protect-configs`,
             },
           ],
         },
@@ -59,7 +60,7 @@ function renderClaudeSettings(_config: ResolvedConfig): string {
           hooks: [
             {
               type: "command",
-              command: `${guard}; ./dist/ai-guardrails hook protect-reads`,
+              command: `${guard}; ${bin} hook protect-reads`,
             },
           ],
         },

--- a/tests/generators/__snapshots__/claude-settings.test.ts.snap
+++ b/tests/generators/__snapshots__/claude-settings.test.ts.snap
@@ -45,7 +45,7 @@ exports[`claudeSettingsGenerator generate output matches snapshot 1`] = `
         "hooks": [
           {
             "type": "command",
-            "command": "[ ! -f ./dist/ai-guardrails ] && exit 0; ./dist/ai-guardrails hook dangerous-cmd"
+            "command": "command -v ai-guardrails >/dev/null 2>&1 || exit 0; ai-guardrails hook dangerous-cmd"
           }
         ]
       },
@@ -54,7 +54,7 @@ exports[`claudeSettingsGenerator generate output matches snapshot 1`] = `
         "hooks": [
           {
             "type": "command",
-            "command": "[ ! -f ./dist/ai-guardrails ] && exit 0; ./dist/ai-guardrails hook protect-configs"
+            "command": "command -v ai-guardrails >/dev/null 2>&1 || exit 0; ai-guardrails hook protect-configs"
           }
         ]
       },
@@ -63,7 +63,7 @@ exports[`claudeSettingsGenerator generate output matches snapshot 1`] = `
         "hooks": [
           {
             "type": "command",
-            "command": "[ ! -f ./dist/ai-guardrails ] && exit 0; ./dist/ai-guardrails hook protect-reads"
+            "command": "command -v ai-guardrails >/dev/null 2>&1 || exit 0; ai-guardrails hook protect-reads"
           }
         ]
       }

--- a/tests/generators/claude-settings.test.ts
+++ b/tests/generators/claude-settings.test.ts
@@ -68,6 +68,17 @@ describe("claudeSettingsGenerator", () => {
     expect(editHook).toBeDefined();
   });
 
+  test("hook commands use command -v guard not file-existence guard", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    expect(output).toContain("command -v ai-guardrails");
+    expect(output).not.toContain("[ ! -f");
+  });
+
+  test("hook commands do not reference ./dist/", () => {
+    const output = claudeSettingsGenerator.generate(makeConfig());
+    expect(output).not.toContain("./dist/");
+  });
+
   test("generate output matches snapshot", () => {
     const output = claudeSettingsGenerator.generate(makeConfig());
     expect(output).toMatchSnapshot();


### PR DESCRIPTION
## Summary
- Replace `[ ! -f ./dist/ai-guardrails ]` guard with `command -v ai-guardrails`
- All 3 PreToolUse hooks now use PATH lookup instead of hardcoded dev path
- Fixes hooks being silently inert in all consumer projects

## Spec
SPEC-012-hook-binary-resolution

## Test Plan
- [x] Existing tests updated with new guard pattern
- [x] Snapshot updated
- [x] Typecheck passes
- [x] Lint passes

Closes #181