### PR TITLE
chore: disable CodeRabbit auto-review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Adds `.coderabbit.yaml` with `reviews.auto_review.enabled: false`. CodeRabbit will no longer auto-review PRs, but manual `@coderabbitai` pings still work. cc-review is the active auto-reviewer.