### PR TITLE
ci: grant WebSearch + WebFetch for qsm-strict-review v2.0.0

### DIFF
--- a/.github/workflows/cc-review-interactive.yml
+++ b/.github/workflows/cc-review-interactive.yml
@@ -137,7 +137,7 @@ jobs:
           cat /tmp/prompt.txt | claude -p \
             --max-turns 75 \
             --model claude-sonnet-4-6 \
-            --allowedTools "Bash(gh:*),Bash(git:*),Bash(cat:*),Bash(npx:*),Bash(tsx:*),Bash(jq:*),Bash(for:*),Read,Glob,Grep,Agent"
+            --allowedTools "Bash(gh:*),Bash(git:*),Bash(cat:*),Bash(npx:*),Bash(tsx:*),Bash(jq:*),Bash(for:*),Read,Glob,Grep,Agent,WebSearch,WebFetch"
 
       - name: Update status comment
         if: always()

--- a/.github/workflows/cc-review.yml
+++ b/.github/workflows/cc-review.yml
@@ -177,4 +177,4 @@ jobs:
           cat /tmp/prompt.txt | claude -p \
             --max-turns 75 \
             --model claude-sonnet-4-6 \
-            --allowedTools "Bash(gh:*),Bash(git:*),Bash(cat:*),Bash(npx:*),Bash(tsx:*),Bash(jq:*),Bash(for:*),Read,Glob,Grep,Agent"
+            --allowedTools "Bash(gh:*),Bash(git:*),Bash(cat:*),Bash(npx:*),Bash(tsx:*),Bash(jq:*),Bash(for:*),Read,Glob,Grep,Agent,WebSearch,WebFetch"


### PR DESCRIPTION
Adds `WebSearch` and `WebFetch` to the cc-review workflow's `--allowedTools` so the bot can run the qsm-strict-review v2.0.0 pipeline. Without these, the feature-researcher agent in Phase 0 can't look up known pitfalls / AI-common mistakes, and the strict mode falls back to the older review-pr template.