### PR TITLE
fix(ci): build before tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
             exit 1
           fi
 
+      - name: Build host binaries (E2E tests need dist/ai-guardrails)
+        run: bun run build:all
+
       - name: Run tests
         run: bun test
 


### PR DESCRIPTION
Mirrors check.yml — E2E tests need dist/ai-guardrails. v4.0.0 tag failed on this exact ENOENT. Fix-forward then re-tag.