### PR TITLE
chore(npm): scope package as @questi0nm4rk/ai-guardrails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-guardrails",
+  "name": "@questi0nm4rk/ai-guardrails",
   "version": "4.0.0",
   "type": "module",
   "files": [


### PR DESCRIPTION
Unscoped `ai-guardrails` is squatted; matches existing @questi0nm4rk/* tools. v4.0.0 already published manually from local.