### PR TITLE
docs: fix stale cc-review header comment

### DIFF
--- a/.github/workflows/cc-review-interactive.yml
+++ b/.github/workflows/cc-review-interactive.yml
@@ -10,7 +10,7 @@
 #  the workflow as data (it can only select answer-only mode or override the
 #  re-review gate — it can never force an approval).
 #
-#  The shared pipeline lives in the composite action .github/actions/cc-review-run.
+#  The shared pipeline lives in scripts/ci-run.sh (cloned at runtime from cc-review).
 # ============================================================================
 name: cc-review interactive
 

--- a/.github/workflows/cc-review.yml
+++ b/.github/workflows/cc-review.yml
@@ -12,9 +12,9 @@
 #  (see cc-review-interactive.yml). The `cc-review` label and a manual
 #  workflow_dispatch are always-on overrides; the `no-review` label suppresses.
 #
-#  The shared pipeline (clone/prefetch/install/run/push) lives ONCE in the
-#  composite action .github/actions/cc-review-run — both this and the interactive
-#  workflow call it, so the heavy logic is edited in one place.
+#  The shared pipeline (prefetch/install/run/push) lives ONCE in scripts/ci-run.sh in
+#  the cc-review repo — both this and the interactive workflow clone cc-review at runtime
+#  (with the App token) and run it, so the heavy logic is edited in one place.
 #
 #  Requires repo secrets: CLAUDE_CODE_OAUTH_TOKEN, REVIEWER_APP_CLIENT_ID,
 #  REVIEWER_APP_PRIVATE_KEY. See the cc-review SPEC.md for GitHub App setup.


### PR DESCRIPTION
Sync corrected workflow header (composite-action ref -> scripts/ci-run.sh). 🤖 Generated with Claude Code