### PR TITLE
fix(ci): author-guard cc-review interactive (prevents self-comment loop)

### DIFF
--- a/.github/workflows/cc-review-interactive.yml
+++ b/.github/workflows/cc-review-interactive.yml
@@ -28,6 +28,7 @@ jobs:
   respond:
     runs-on: ubuntu-latest
     if: |
+      github.event.comment.user.type != 'Bot' &&
       contains(github.event.comment.body, '@cc-review') &&
       (github.event_name == 'pull_request_review_comment' ||
        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null))


### PR DESCRIPTION
Adds `github.event.comment.user.type != 'Bot'` to the `cc-review interactive` job's `if:`, so the bot's own status comments can never re-trigger it. Prevents the self-sustaining loop that exhausted the org Anthropic quota (cc-review#51). One-line guard; no behavior change for human `@cc-review` pings.